### PR TITLE
feat: implement product-grade audit phase 1-6 fixes (error boundaries, CI & lint, auth tests, GPS throttling, API refactor, code splitting)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   check:
     name: Lint, Typecheck & Test
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Taipei
     steps:
       # v4.2.2
       - name: Check out repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Lint, Typecheck & Test
+    runs-on: ubuntu-latest
+    steps:
+      # v4.2.2
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # v4.2.0
+      - name: Set up Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Biome Lint
+        run: npm run lint
+
+      - name: Run Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run Tests
+        run: npm test

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,17 +7,22 @@
   },
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!node_modules", "!.next", "!dist", "!build"]
+    "includes": ["**", "!node_modules", "!.next", "!dist", "!build", "!public"]
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noUnknownAtRules": "off"
       }

--- a/docs/plan-phase-1-2-3.md
+++ b/docs/plan-phase-1-2-3.md
@@ -1,0 +1,62 @@
+# 產品級工程修復實作計劃（Phase 1, 2, 3）
+
+本計劃對應稽核報告 `docs/audit/2026-08-18-product-grade-audit.md` 中的建議處理順序 1, 2, 3 項。
+
+---
+
+## 專案規格與約束
+1. **UI/UX 設計規範**：嚴格遵循 `ui-ux-pro-max` 技能標準與本專案既有設計體系（Tailwind CSS, Shadcn UI, 多語系 i18n, Dark/Light/High-Contrast 模式, 44px 觸控目標, WCAG 2.1 AA 無障礙標準）。
+2. **Commit 策略**：每個 Phase 獨立進行 Conventional Commit。
+3. **隔離規範**：不 commit `docs/audit/2026-08-18-product-grade-audit.md`。
+
+---
+
+## Phase 1：建立 Error Boundary 與 Next.js 錯誤頁面（P1-1）
+### 目標
+防止任何未預期例外（如 WebGL 上下文遺失、語音串流例外、JSON 解析失敗）造成全白屏崩潰，提供局部與全域錯誤降級與重試能力。
+
+### 實作細節
+1. **`src/components/shared/ErrorBoundary.tsx`**：
+   - 封裝通用 React Class Component `ErrorBoundary`，支援 `fallback` 自訂函式或預設的無障礙錯誤卡片。
+   - 支援 `onReset` 回呼與重試按鈕（`ui-ux-pro-max` 規範：44px 觸控熱區、`role="alert"`、`aria-live="assertive"`）。
+2. **`src/app/[lng]/error.tsx`**：
+   - Next.js 路由層級 Client Error Component，支援多語系 i18n 翻譯（"發生未預期錯誤"、"重試"、"返回首頁"）。
+3. **`src/app/global-error.tsx`**：
+   - 根層級 HTML/Body Error Component，在最外層根版面失敗時提供基本樣式與復原機制。
+4. **單元測試**：
+   - `src/components/shared/__tests__/ErrorBoundary.test.tsx` 驗證錯誤捕捉、降級卡片渲染與重試呼叫。
+
+---
+
+## Phase 2：建立 CI 護欄並修復 61 個 Biome Lint 錯誤（P1-2）
+### 目標
+建立自動化 PR 品質檢查，並徹底清除既有 61 個 Biome Linter 錯誤與 76 個警告。
+
+### 實作細節
+1. **`.github/workflows/ci.yml`**：
+   - 設定 PR 與 push 觸發。
+   - 執行 `npm run lint`、`npx tsc --noEmit`、`npm test`。
+2. **修復 61 個 Biome 錯誤**：
+   - `src/app/globals.css`：調整 `@layer base *` 順序與移除衝突的 `!important` 樣式。
+   - `src/components/A11yFacilityPin.tsx:56`：將靜態互動 div 轉為具備語意、鍵盤導航與 role 屬性的可及性元件。
+   - `src/components/BottomSheet/BusPanel.tsx`：修正 `role="radio"` 在非 radiogroup 的結構問題，以及 `role="list"` 缺乏 listitem 的問題。
+   - `src/components/BottomSheet/HazardReportPanel.tsx`：修正 `role="radio"` 與原生 `<img>` 警告。
+   - `src/components/BottomSheet/HomeContent.tsx`：修正陣列 index key（改用 `placeKey`）與 `role="group"`。
+   - `A11yPanel.tsx`、`ParkingPanel.tsx`、`route.ts`：自動整理 import 排序。
+3. **驗證**：
+   - `npm run lint` 達到 0 errors、exit=0。
+
+---
+
+## Phase 3：補齊登出對話隱私清理測試（P1-3）
+### 目標
+確保使用者於共用裝置登出時，AI 對話紀錄與快照被確實清空，防止隱私洩漏。
+
+### 實作細節
+1. **`src/stores/__tests__/useAuthStore.test.ts`**：
+   - 新增 `logout()` 測試案例：
+     - 模擬使用者登入並在 `useChatStore` 填充對話訊息與 active tools。
+     - 執行 `useAuthStore.getState().logout()`。
+     - 斷言驗證 `useAuthStore.user === null`、`session === null`、`useChatStore.messages === []`。
+2. **突變驗證**：
+   - 移除 `useAuthStore.ts` 中的 `useChatStore.getState().clearAll()`，確認測試必紅（Killed）；復原後變綠。

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.2.0",
+        "@biomejs/biome": "^2.5.9",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -162,9 +162,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.0.tgz",
-      "integrity": "sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+      "integrity": "sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -178,20 +178,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.2.0",
-        "@biomejs/cli-darwin-x64": "2.2.0",
-        "@biomejs/cli-linux-arm64": "2.2.0",
-        "@biomejs/cli-linux-arm64-musl": "2.2.0",
-        "@biomejs/cli-linux-x64": "2.2.0",
-        "@biomejs/cli-linux-x64-musl": "2.2.0",
-        "@biomejs/cli-win32-arm64": "2.2.0",
-        "@biomejs/cli-win32-x64": "2.2.0"
+        "@biomejs/cli-darwin-arm64": "2.5.9",
+        "@biomejs/cli-darwin-x64": "2.5.9",
+        "@biomejs/cli-linux-arm64": "2.5.9",
+        "@biomejs/cli-linux-arm64-musl": "2.5.9",
+        "@biomejs/cli-linux-x64": "2.5.9",
+        "@biomejs/cli-linux-x64-musl": "2.5.9",
+        "@biomejs/cli-win32-arm64": "2.5.9",
+        "@biomejs/cli-win32-x64": "2.5.9"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.0.tgz",
-      "integrity": "sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+      "integrity": "sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==",
       "cpu": [
         "arm64"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.0.tgz",
-      "integrity": "sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+      "integrity": "sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==",
       "cpu": [
         "x64"
       ],
@@ -223,13 +223,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.0.tgz",
-      "integrity": "sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+      "integrity": "sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -240,13 +243,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.0.tgz",
-      "integrity": "sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+      "integrity": "sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -257,13 +263,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.0.tgz",
-      "integrity": "sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+      "integrity": "sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -274,13 +283,16 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.0.tgz",
-      "integrity": "sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+      "integrity": "sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -291,9 +303,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.0.tgz",
-      "integrity": "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+      "integrity": "sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==",
       "cpu": [
         "arm64"
       ],
@@ -308,9 +320,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.0.tgz",
-      "integrity": "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+      "integrity": "sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.2.0",
+    "@biomejs/biome": "^2.5.9",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/src/app/[lng]/error.tsx
+++ b/src/app/[lng]/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+import StatusPage from "@/components/shared/StatusPage";
+import { useAppTranslation } from "@/i18n/client";
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorProps) {
+  const { t } = useAppTranslation();
+  const isDev = process.env.NODE_ENV !== "production";
+
+  useEffect(() => {
+    console.error(
+      "[RouteError] Unhandled error caught in route error boundary:",
+      error,
+    );
+  }, [error]);
+
+  return (
+    <StatusPage
+      status="error"
+      title={t("errorTitle", "發生未預期錯誤")}
+      description={t(
+        "errorDescription",
+        "應用程式遇到未預期的問題，請嘗試重新載入或返回首頁。",
+      )}
+      code={error.digest}
+      primaryAction={{
+        label: t("errorRetry", "重新嘗試"),
+        onClick: reset,
+      }}
+      secondaryAction={{
+        label: t("errorGoHome", "返回首頁"),
+        href: "/",
+      }}
+    >
+      {(isDev || error.message) && (
+        <details className="text-left text-xs text-muted-foreground group mt-2">
+          <summary className="cursor-pointer font-medium hover:text-foreground select-none">
+            {t("errorDetails", "詳細錯誤資訊")}
+          </summary>
+          <pre className="mt-2 max-h-36 overflow-auto rounded bg-muted/80 p-2.5 font-mono text-[11px] leading-relaxed text-foreground whitespace-pre-wrap break-all border border-border">
+            {error.message}
+            {error.stack ? `\n\n${error.stack}` : ""}
+          </pre>
+        </details>
+      )}
+    </StatusPage>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface GlobalErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  useEffect(() => {
+    console.error(
+      "[GlobalError] Unhandled error caught in root global error boundary:",
+      error,
+    );
+  }, [error]);
+
+  const handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    } else {
+      reset();
+    }
+  };
+
+  return (
+    <html lang="zh-TW">
+      <head>
+        <title>系統發生錯誤 - 無障礙智慧地圖</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      </head>
+      <body
+        style={{
+          margin: 0,
+          padding: 0,
+          fontFamily:
+            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans TC", sans-serif',
+          backgroundColor: "#f8fafc",
+          color: "#0f172a",
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxSizing: "border-box",
+        }}
+      >
+        <main
+          role="alert"
+          aria-live="assertive"
+          aria-atomic="true"
+          style={{
+            maxWidth: "480px",
+            width: "90%",
+            padding: "24px",
+            margin: "16px auto",
+            backgroundColor: "#ffffff",
+            borderRadius: "12px",
+            boxShadow:
+              "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
+            border: "1px solid #e2e8f0",
+            textAlign: "center",
+          }}
+        >
+          <div
+            style={{
+              width: "56px",
+              height: "56px",
+              margin: "0 auto 16px",
+              borderRadius: "50%",
+              backgroundColor: "#fee2e2",
+              color: "#dc2626",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            aria-hidden="true"
+          >
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="錯誤提示圖示"
+            >
+              <title>錯誤提示圖示</title>
+              <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+              <line x1="12" y1="9" x2="12" y2="13" />
+              <line x1="12" y1="17" x2="12.01" y2="17" />
+            </svg>
+          </div>
+
+          <h1
+            style={{
+              fontSize: "20px",
+              fontWeight: 700,
+              margin: "0 0 8px",
+              color: "#0f172a",
+            }}
+          >
+            系統發生重大錯誤
+          </h1>
+
+          <p
+            style={{
+              fontSize: "14px",
+              color: "#64748b",
+              lineHeight: 1.6,
+              margin: "0 0 16px",
+            }}
+          >
+            應用程式核心元件發生未預期的錯誤，請嘗試重新載入整個頁面或返回首頁。
+          </p>
+
+          {error?.digest && (
+            <p
+              style={{
+                fontSize: "12px",
+                color: "#94a3b8",
+                margin: "0 0 16px",
+                fontFamily: "monospace",
+              }}
+            >
+              錯誤代碼：{error.digest}
+            </p>
+          )}
+
+          {error?.message && (
+            <details
+              style={{
+                textAlign: "left",
+                fontSize: "12px",
+                color: "#64748b",
+                marginBottom: "20px",
+                padding: "8px 12px",
+                backgroundColor: "#f1f5f9",
+                borderRadius: "6px",
+                border: "1px solid #e2e8f0",
+              }}
+            >
+              <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+                詳細錯誤資訊
+              </summary>
+              <pre
+                style={{
+                  marginTop: "8px",
+                  maxHeight: "120px",
+                  overflow: "auto",
+                  fontFamily: "monospace",
+                  fontSize: "11px",
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-all",
+                  color: "#334155",
+                }}
+              >
+                {error.message}
+                {error.stack ? `\n\n${error.stack}` : ""}
+              </pre>
+            </details>
+          )}
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+            }}
+          >
+            <button
+              type="button"
+              onClick={handleReload}
+              style={{
+                minHeight: "44px",
+                padding: "10px 20px",
+                fontSize: "14px",
+                fontWeight: 600,
+                color: "#ffffff",
+                backgroundColor: "#0284c7",
+                border: "none",
+                borderRadius: "8px",
+                cursor: "pointer",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: "8px",
+                boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+              }}
+              aria-label="重新載入頁面"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="重新載入圖示"
+              >
+                <title>重新載入圖示</title>
+                <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+                <path d="M21 3v5h-5" />
+                <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+                <path d="M8 16H3v5" />
+              </svg>
+              <span>重新載入頁面</span>
+            </button>
+
+            <a
+              href="/"
+              style={{
+                minHeight: "44px",
+                padding: "10px 20px",
+                fontSize: "13px",
+                color: "#64748b",
+                textDecoration: "none",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              返回首頁
+            </a>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,8 +11,15 @@
   }
 }
 
-body {
-  pointer-events: auto !important;
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground font-sans;
+    pointer-events: auto;
+  }
 }
 
 .material-symbols-outlined {
@@ -453,30 +460,20 @@ img.adp-marker2 {
 }
 
 .high-contrast * {
-  font-weight: 500 !important;
+  font-weight: 500;
 }
 
 .high-contrast button,
 .high-contrast a,
 .high-contrast [role="button"] {
-  font-weight: 600 !important;
-  border-width: 2px !important;
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-
-  body {
-    @apply bg-background text-foreground font-sans;
-  }
+  font-weight: 600;
+  border-width: 2px;
 }
 
 /* MapLibre's own zoom in/out buttons ship at 29×29px — under the 44×44
    touch-target floor everywhere else in the app. MapLibre doesn't expose a
    size prop for its NavigationControl, so this overrides its stylesheet. */
-.maplibregl-ctrl-group button {
-  width: 44px !important;
-  height: 44px !important;
+.maplibregl-ctrl.maplibregl-ctrl-group button {
+  width: 44px;
+  height: 44px;
 }

--- a/src/components/A11yFacilityPin.tsx
+++ b/src/components/A11yFacilityPin.tsx
@@ -53,7 +53,9 @@ export default function A11yFacilityPin({ place }: { place: MarkerType }) {
               setOpen(true);
             }}
           >
-            <div
+            <button
+              type="button"
+              aria-label={place.content?.title || "設施"}
               onMouseEnter={() => setOpen(true)}
               onMouseLeave={() => setOpen(false)}
               className={cn(
@@ -63,7 +65,7 @@ export default function A11yFacilityPin({ place }: { place: MarkerType }) {
               )}
             >
               {A11yIcon()}
-            </div>
+            </button>
           </Marker>
         </div>
       </HoverCardTrigger>

--- a/src/components/AIChatBot.tsx
+++ b/src/components/AIChatBot.tsx
@@ -138,8 +138,10 @@ function ToolResultsBox({ activities }: { activities: ToolActivity[] }) {
       className="flex flex-col gap-1.5 mt-2 w-full max-w-[88vw] sm:max-w-[440px] rounded-2xl border border-border/50 bg-card/70 dark:bg-card/50 backdrop-blur-md p-2.5 shadow-2xs transition-all"
     >
       {/* 頂部 Header：摘要與折疊按鈕 */}
-      <div
-        className="flex items-center justify-between gap-2 px-1 cursor-pointer select-none"
+      <button
+        type="button"
+        aria-expanded={!isCollapsed}
+        className="flex w-full items-center justify-between gap-2 px-1 cursor-pointer select-none text-left rounded-md hover:bg-muted/40 transition-colors"
         onClick={() => setIsCollapsed(!isCollapsed)}
       >
         <div className="flex items-center gap-1.5 min-w-0">
@@ -157,15 +159,9 @@ function ToolResultsBox({ activities }: { activities: ToolActivity[] }) {
           </Badge>
         </div>
 
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setIsCollapsed(!isCollapsed);
-          }}
-          className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors px-1.5 py-0.5 rounded-md hover:bg-muted/60"
-          aria-expanded={!isCollapsed}
-          aria-label={isCollapsed ? "展開卡片" : "收起卡片"}
+        <span
+          className="flex items-center gap-1 text-[11px] text-muted-foreground transition-colors px-1.5 py-0.5 rounded-md"
+          aria-hidden="true"
         >
           <span>{isCollapsed ? "展開" : "收起"}</span>
           {isCollapsed ? (
@@ -173,8 +169,8 @@ function ToolResultsBox({ activities }: { activities: ToolActivity[] }) {
           ) : (
             <ChevronUp className="h-3.5 w-3.5" />
           )}
-        </button>
-      </div>
+        </span>
+      </button>
 
       {/* 展開後的內容 */}
       <AnimatePresence initial={false}>
@@ -191,7 +187,7 @@ function ToolResultsBox({ activities }: { activities: ToolActivity[] }) {
               <div className="flex gap-1.5 overflow-x-auto pb-1 px-0.5 scrollbar-none snap-x">
                 {groups.map((g, idx) => (
                   <button
-                    key={`${g.heading}-${idx}`}
+                    key={`${g.heading}-${g.icon}`}
                     type="button"
                     onClick={() => setActiveTab(idx)}
                     className={cn(
@@ -339,8 +335,10 @@ export default function AIChatBot({ active = true }: { active?: boolean }) {
   ];
 
   useEffect(() => {
-    scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages]);
+    if (messages.length > 0) {
+      scrollRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+    }
+  }, [messages.length]);
 
   // The unified home-screen input hands off a question-shaped query via the
   // store instead of calling `handleSend` directly: this component owns its
@@ -420,6 +418,7 @@ export default function AIChatBot({ active = true }: { active?: boolean }) {
       <ScrollArea className="flex-1 overflow-hidden pt-1 [&>[data-radix-scroll-area-viewport]>div]:!block">
         <CardContent className="min-h-full space-y-3" ref={scrollRef}>
           {messages.map((m, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: chat messages are an append-only stream without persistent IDs
             <Fragment key={i}>
               <MessageBubble message={m} />
             </Fragment>

--- a/src/components/BottomSheet/A11yPanel.tsx
+++ b/src/components/BottomSheet/A11yPanel.tsx
@@ -12,10 +12,10 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useFetchLocation } from "@/hook/useFetchLocation";
 import { useAppTranslation } from "@/i18n/client";
 import { getNearbyHazardReports, getNearbyParking } from "@/lib/api/a11y";
 import { haversineMeters } from "@/lib/geo";
-import { useFetchLocation } from "@/hook/useFetchLocation";
 import { cn } from "@/lib/utils";
 import useMapStore from "@/stores/useMapStore";
 import { A11yEnum } from "@/types";

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -186,7 +186,7 @@ export default function BottomSheet() {
   const coachMarksActive = useOnboardingStore((s) => s.coachMarksActive);
   const stepListOpen = useNavStore((s) => s.stepListOpen);
   const setStepListOpen = useNavStore((s) => s.setStepListOpen);
-  const [snap, setSnap] = useState<"peek" | "half" | "full">("peek");
+  const [, setSnap] = useState<"peek" | "half" | "full">("peek");
   const [sheetHeight, setSheetHeight] = useState(SNAP_POINTS.peek);
   const [isDragging, setIsDragging] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
@@ -609,45 +609,24 @@ export default function BottomSheet() {
           <div
             ref={mobileContentScrollRef}
             className={cn(
-              "flex-1 overflow-x-hidden pb-safe",
+              "flex-1 overflow-x-hidden pb-safe relative",
               showAssistant ? "overflow-hidden px-0" : "px-4",
               atPeek && !showAssistant
                 ? "overflow-y-hidden"
                 : "overflow-y-auto",
             )}
-            role={
-              atPeek && sheetMode === "home" && !showAssistant
-                ? "button"
-                : undefined
-            }
-            tabIndex={
-              atPeek && sheetMode === "home" && !showAssistant ? 0 : undefined
-            }
-            aria-label={
-              atPeek && sheetMode === "home" && !showAssistant
-                ? t("expandPanel", "展開面板")
-                : undefined
-            }
-            onClick={
-              atPeek && sheetMode === "home" && !showAssistant
-                ? () => {
-                    setSnap("half");
-                    setSheetHeight(SNAP_POINTS.half);
-                  }
-                : undefined
-            }
-            onKeyDown={
-              atPeek && sheetMode === "home" && !showAssistant
-                ? (e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      setSnap("half");
-                      setSheetHeight(SNAP_POINTS.half);
-                    }
-                  }
-                : undefined
-            }
           >
+            {atPeek && sheetMode === "home" && !showAssistant && (
+              <button
+                type="button"
+                className="absolute inset-0 z-10 w-full h-full opacity-0 cursor-pointer"
+                aria-label={t("expandPanel", "展開面板")}
+                onClick={() => {
+                  setSnap("half");
+                  setSheetHeight(SNAP_POINTS.half);
+                }}
+              />
+            )}
             {/* Both stay mounted — a conditional-render ternary here used to
                 unmount `AIChatBot` every time the assistant closed, which
                 reset its conversation (state now lives in a store so that

--- a/src/components/BottomSheet/BusPanel.tsx
+++ b/src/components/BottomSheet/BusPanel.tsx
@@ -44,12 +44,15 @@ const CityNameMap: Record<string, string> = {
 function RouteStopCard({ stop }: { stop: RouteDetailStop }) {
   const hasEstimate =
     stop.estimateMinutes !== null && stop.estimateMinutes >= 0;
-  const isArrivingSoon = hasEstimate && stop.estimateMinutes! < 3;
+  const isArrivingSoon =
+    hasEstimate &&
+    typeof stop.estimateMinutes === "number" &&
+    stop.estimateMinutes < 3;
 
   let badgeText = stop.statusLabel || "尚未發車";
   let badgeColor = "text-muted-foreground bg-muted/60";
 
-  if (hasEstimate) {
+  if (hasEstimate && typeof stop.estimateMinutes === "number") {
     if (isArrivingSoon) {
       badgeText = stop.estimateMinutes === 0 ? "進站中" : "即將到站";
       badgeColor =
@@ -61,14 +64,14 @@ function RouteStopCard({ stop }: { stop: RouteDetailStop }) {
   }
 
   return (
-    <div className="p-3 rounded-xl bg-muted/40 border border-border/30">
+    <li className="p-3 rounded-xl bg-muted/40 border border-border/30 list-none">
       <div className="flex items-center justify-between gap-2">
         <p className="text-sm font-semibold truncate flex-1">{stop.name}</p>
         <Badge variant="secondary" className={`text-xs shrink-0 ${badgeColor}`}>
           {badgeText}
         </Badge>
       </div>
-    </div>
+    </li>
   );
 }
 
@@ -341,14 +344,10 @@ export default function BusPanel({
 
           {direction !== null && routeDetails.length > 0 && (
             <div className="space-y-3">
-              <div
-                className="flex rounded-lg bg-muted/60 border border-border/30 p-0.5 text-sm"
-                role="radiogroup"
-              >
+              <div className="flex rounded-lg bg-muted/60 border border-border/30 p-0.5 text-sm">
                 <button
                   type="button"
-                  role="radio"
-                  aria-checked={direction === 0}
+                  aria-pressed={direction === 0}
                   onClick={() => setDirection(0)}
                   className={`flex-1 px-3 py-1.5 rounded-md transition-all duration-200 truncate ${
                     direction === 0
@@ -360,8 +359,7 @@ export default function BusPanel({
                 </button>
                 <button
                   type="button"
-                  role="radio"
-                  aria-checked={direction === 1}
+                  aria-pressed={direction === 1}
                   onClick={() => setDirection(1)}
                   className={`flex-1 px-3 py-1.5 rounded-md transition-all duration-200 truncate ${
                     direction === 1
@@ -402,14 +400,11 @@ export default function BusPanel({
               <p className="text-sm text-muted-foreground">{error}</p>
             </div>
           ) : currentDirectionDetails?.stops ? (
-            <div
-              className="space-y-2 flex-1 overflow-y-auto pr-2 pb-4"
-              role="list"
-            >
-              {currentDirectionDetails.stops.map((stop, idx) => (
-                <RouteStopCard key={`${stop.seq}-${idx}`} stop={stop} />
+            <ul className="space-y-2 flex-1 overflow-y-auto pr-2 pb-4">
+              {currentDirectionDetails.stops.map((stop) => (
+                <RouteStopCard key={`${stop.seq}-${stop.name}`} stop={stop} />
               ))}
-            </div>
+            </ul>
           ) : null}
         </div>
       ) : selectedStop ? (
@@ -526,9 +521,9 @@ export default function BusPanel({
                             heading={city}
                             className="px-1"
                           >
-                            {routes.map((r, i) => (
+                            {routes.map((r) => (
                               <CommandItem
-                                key={`${r.city}-${r.routeName}-${i}`}
+                                key={`${r.city}-${r.routeName}-${r.departure}-${r.destination}`}
                                 onSelect={() => handleRouteSelect(r)}
                                 className="flex flex-col items-start px-3 py-2 cursor-pointer"
                               >

--- a/src/components/BottomSheet/HazardReportPanel.tsx
+++ b/src/components/BottomSheet/HazardReportPanel.tsx
@@ -232,17 +232,12 @@ export default function HazardReportPanel({
         >
           {t("hazardType")}
         </span>
-        <div
-          role="radiogroup"
-          aria-labelledby={hazardTypeLabelId}
-          className="flex gap-2"
-        >
+        <div className="flex gap-2">
           {HAZARD_TYPES.map((ht) => (
             <button
               key={ht.value}
               type="button"
-              role="radio"
-              aria-checked={hazardType === ht.value}
+              aria-pressed={hazardType === ht.value}
               onClick={() => setHazardType(ht.value)}
               className={`flex-1 flex flex-col items-center gap-1.5 p-3 rounded-xl text-xs font-medium transition-all border ${
                 hazardType === ht.value
@@ -287,6 +282,7 @@ export default function HazardReportPanel({
         />
         {photoPreview ? (
           <div className="relative">
+            {/* biome-ignore lint/performance/noImgElement: local data URL preview from file picker */}
             <img
               src={photoPreview}
               alt="preview"

--- a/src/components/BottomSheet/HomeContent.tsx
+++ b/src/components/BottomSheet/HomeContent.tsx
@@ -12,7 +12,7 @@ import { useAppTranslation } from "@/i18n/client";
 import { QUICK_ACTION_DEFS } from "@/lib/quickActions";
 import { cn } from "@/lib/utils";
 import useAuthStore from "@/stores/useAuthStore";
-import useMapStore from "@/stores/useMapStore";
+import useMapStore, { placeKey } from "@/stores/useMapStore";
 import useQuickActionsStore from "@/stores/useQuickActionsStore";
 import useVoiceStore from "@/stores/useVoiceStore";
 import type { PlaceDetail } from "@/types";
@@ -235,16 +235,7 @@ export default function HomeContent() {
              this a chip cut off mid-button (e.g. "公車到站" on a wide
              desktop panel) just looked truncated, not scrollable. */
           <div className="relative">
-            <div
-              role="group"
-              className="flex gap-2 overflow-x-auto no-scrollbar snap-x snap-mandatory -mx-4 px-4 pb-0.5"
-              aria-label={t("quickActionsScrollHint", {
-                count: QUICK_ACTION_DEFS.filter((d) =>
-                  enabledActions.includes(d.id),
-                ).length,
-                defaultValue: "快捷功能，共 {{count}} 項，可左右滑動",
-              })}
-            >
+            <div className="flex gap-2 overflow-x-auto no-scrollbar snap-x snap-mandatory -mx-4 px-4 pb-0.5">
               {QUICK_ACTION_DEFS.filter((d) =>
                 enabledActions.includes(d.id),
               ).map((def) => (
@@ -289,14 +280,14 @@ export default function HomeContent() {
             )}
           </div>
           <div className="space-y-1">
-            {savedPlaces.slice(0, 5).map((item, idx) => {
+            {savedPlaces.slice(0, 5).map((item) => {
               const name =
                 item.kind === "place"
                   ? item.place.name || item.place.fullAddress
                   : item.address;
               return (
                 <button
-                  key={idx}
+                  key={placeKey(item)}
                   type="button"
                   onClick={() => handlePlaceChange(item)}
                   className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-muted/60 transition-colors text-left"
@@ -318,14 +309,14 @@ export default function HomeContent() {
             {t("recentSearches")}
           </h2>
           <div className="space-y-1">
-            {searchHistory.slice(0, 5).map((item, idx) => {
+            {searchHistory.slice(0, 5).map((item) => {
               const name =
                 item.kind === "place"
                   ? item.place.name || item.place.fullAddress
                   : item.address;
               return (
                 <button
-                  key={idx}
+                  key={placeKey(item)}
                   type="button"
                   onClick={() => handlePlaceChange(item)}
                   className="w-full flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-muted/60 transition-colors text-left"

--- a/src/components/BottomSheet/NavigationContent.tsx
+++ b/src/components/BottomSheet/NavigationContent.tsx
@@ -109,7 +109,7 @@ export default function NavigationContent() {
           const passed = i < currentStep;
           return (
             <button
-              key={`${i}-${step.text}`}
+              key={`${step.type}-${step.text}-${step.distanceM ?? 0}-${step.polylineIndex ?? 0}`}
               ref={active ? currentRef : undefined}
               type="button"
               onClick={() => setStepIndex(i)}

--- a/src/components/BottomSheet/ParkingPanel.tsx
+++ b/src/components/BottomSheet/ParkingPanel.tsx
@@ -11,10 +11,10 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useFetchLocation } from "@/hook/useFetchLocation";
 import { useAppTranslation } from "@/i18n/client";
 import { getNearbyParking } from "@/lib/api/a11y";
 import { haversineMeters } from "@/lib/geo";
-import { useFetchLocation } from "@/hook/useFetchLocation";
 import useMapStore from "@/stores/useMapStore";
 import { formatDistance, type ParkingNearbyItem } from "@/types/route";
 import { Badge } from "../ui/badge";

--- a/src/components/BottomSheet/PlaceContent.tsx
+++ b/src/components/BottomSheet/PlaceContent.tsx
@@ -338,10 +338,10 @@ export default function PlaceContent() {
   }
 
   const name = isPlace
-    ? place!.name || place!.fullAddress || ""
+    ? place?.name || place?.fullAddress || ""
     : infoShow.address;
-  const address = isPlace ? place!.fullAddress : infoShow.address;
-  const addressParts = isPlace ? place!.addressComponents : null;
+  const address = isPlace ? place?.fullAddress : infoShow.address;
+  const addressParts = isPlace ? place?.addressComponents : null;
   const hasA11y = nearbyBathrooms.length > 0 || nearbyMetro.length > 0;
 
   return (
@@ -364,7 +364,7 @@ export default function PlaceContent() {
           <h1 className="text-lg font-bold leading-tight line-clamp-2">
             {name}
           </h1>
-          {isPlace && place!.name && (
+          {isPlace && place?.name && (
             <p className="text-sm text-muted-foreground mt-0.5 line-clamp-2">
               {address}
             </p>
@@ -374,34 +374,36 @@ export default function PlaceContent() {
 
       {/* Badges */}
       <div className="flex flex-wrap gap-2">
-        {isPlace && place!.typeLabel && (
+        {isPlace && place?.typeLabel && (
           <Badge variant="secondary" className="rounded-full">
-            {place!.typeLabel}
+            {place?.typeLabel}
           </Badge>
         )}
-        {isPlace && !place!.typeLabel && place!.placeType && (
+        {isPlace && !place?.typeLabel && place?.placeType && (
           <Badge variant="secondary" className="rounded-full">
-            {getPlaceTypeLabel(place!.placeType, i18n.language)}
+            {getPlaceTypeLabel(place?.placeType, i18n.language)}
           </Badge>
         )}
         {isPlace && (
           <Badge
             variant={
-              place!.accessibility.status === "accessible"
+              place?.accessibility.status === "accessible"
                 ? "default"
-                : place!.accessibility.status === "limited"
+                : place?.accessibility.status === "limited"
                   ? "secondary"
                   : "outline"
             }
             className="rounded-full gap-1"
           >
             <AccessibilityIcon size={12} />
-            {getAccessibilityStatusLabel(place!.accessibility.status)}
+            {getAccessibilityStatusLabel(
+              place?.accessibility.status ?? "unknown",
+            )}
           </Badge>
         )}
-        {isPlace && place!.externalLinks.osm && (
+        {isPlace && place?.externalLinks.osm && (
           <a
-            href={place!.externalLinks.osm}
+            href={place?.externalLinks.osm}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -414,9 +416,9 @@ export default function PlaceContent() {
             </Badge>
           </a>
         )}
-        {isPlace && place!.externalLinks.google && (
+        {isPlace && place?.externalLinks.google && (
           <a
-            href={place!.externalLinks.google}
+            href={place?.externalLinks.google}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -430,8 +432,8 @@ export default function PlaceContent() {
           </a>
         )}
       </div>
-      {isPlace && place!.attribution && (
-        <p className="text-xs text-muted-foreground">{place!.attribution}</p>
+      {isPlace && place?.attribution && (
+        <p className="text-xs text-muted-foreground">{place?.attribution}</p>
       )}
 
       {/* Actions */}

--- a/src/components/BottomSheet/RouteContent.tsx
+++ b/src/components/BottomSheet/RouteContent.tsx
@@ -172,7 +172,7 @@ export default function RouteContent() {
       <div className="space-y-3">
         {computeRoutes.map((route, index) => (
           <RouteCard
-            key={`${index}-${route.routeId ?? ""}`}
+            key={route.routeId || `${route.routeName}-${route.totalMinutes}`}
             idx={index}
             route={route}
           />

--- a/src/components/BottomSheet/RouteExplanationPanel.tsx
+++ b/src/components/BottomSheet/RouteExplanationPanel.tsx
@@ -66,8 +66,8 @@ export default function RouteExplanationPanel({
           {/* Highlights */}
           {explanation.accessibilityHighlights.length > 0 && (
             <div className="space-y-1.5">
-              {explanation.accessibilityHighlights.map((h, i) => (
-                <div key={i} className="flex items-start gap-2 text-sm">
+              {explanation.accessibilityHighlights.map((h) => (
+                <div key={h} className="flex items-start gap-2 text-sm">
                   <Lightbulb className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
                   <span>{h}</span>
                 </div>
@@ -82,8 +82,8 @@ export default function RouteExplanationPanel({
                 <AlertCircle className="h-4 w-4" />
                 {t("warnings")}
               </h3>
-              {explanation.warnings.map((w, i) => (
-                <p key={i} className="text-sm text-muted-foreground ml-5.5">
+              {explanation.warnings.map((w) => (
+                <p key={w} className="text-sm text-muted-foreground ml-5.5">
                   {w}
                 </p>
               ))}

--- a/src/components/BottomSheet/RoutePlanContent.tsx
+++ b/src/components/BottomSheet/RoutePlanContent.tsx
@@ -40,6 +40,11 @@ interface WaypointRow {
   input: string;
 }
 
+const DISALLOWED_TRAVEL_MODES: Record<string, ("drive" | "motorcycle")[]> = {
+  wheelchair: ["drive", "motorcycle"],
+  visual_impaired: ["drive", "motorcycle"],
+};
+
 export default function RoutePlanContent() {
   const { t } = useAppTranslation();
   const {
@@ -105,25 +110,13 @@ export default function RoutePlanContent() {
       setA11yMode(useOnboardingStore.getState().profile.routeMode);
     }
   }, [onboardingHydrated]);
-  // A wheelchair user isn't self-driving or riding a motorcycle; someone in
-  // "visual impaired" mode isn't either. Rather than let both selections
-  // exist and produce a route that contradicts the a11y mode picked right
-  // next to it, the incompatible transport options are disabled outright.
-  const DISALLOWED_TRAVEL_MODES: Record<string, ("drive" | "motorcycle")[]> = {
-    wheelchair: ["drive", "motorcycle"],
-    visual_impaired: ["drive", "motorcycle"],
-  };
   const disabledTravelModes = DISALLOWED_TRAVEL_MODES[a11yMode] ?? [];
-  // If the a11y mode just changed and stranded the current transport pick
-  // on a now-disabled option, fall back to transit rather than silently
-  // keeping an invalid combination selected.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: only react to
-  // the a11y mode changing, not every render where travelMode/disabledTravelModes differ
   useEffect(() => {
-    if (disabledTravelModes.includes(travelMode as "drive" | "motorcycle")) {
+    const disallowed = DISALLOWED_TRAVEL_MODES[a11yMode] ?? [];
+    if (disallowed.includes(travelMode as "drive" | "motorcycle")) {
       setTravelMode("transit");
     }
-  }, [a11yMode]);
+  }, [a11yMode, travelMode]);
   const [waypointRows, setWaypointRows] = useState<WaypointRow[]>([]);
   const nextWaypointId = useRef(0);
 
@@ -554,10 +547,22 @@ export default function RoutePlanContent() {
           </span>
           <div className="flex gap-1 bg-muted/30 p-1 rounded-2xl w-full overflow-x-auto no-scrollbar">
             {[
-              { id: "transit", icon: Bus, label: t("transit", "大眾運輸") },
-              { id: "drive", icon: Car, label: t("drive", "開車") },
-              { id: "motorcycle", icon: Bike, label: t("motorcycle", "機車") },
-              { id: "walk", icon: Footprints, label: t("walk", "步行") },
+              {
+                id: "transit" as const,
+                icon: Bus,
+                label: t("transit", "大眾運輸"),
+              },
+              { id: "drive" as const, icon: Car, label: t("drive", "開車") },
+              {
+                id: "motorcycle" as const,
+                icon: Bike,
+                label: t("motorcycle", "機車"),
+              },
+              {
+                id: "walk" as const,
+                icon: Footprints,
+                label: t("walk", "步行"),
+              },
             ].map((tm) => {
               const isDisallowed = disabledTravelModes.includes(
                 tm.id as "drive" | "motorcycle",
@@ -575,7 +580,7 @@ export default function RoutePlanContent() {
                       ? "shadow-sm"
                       : "text-muted-foreground hover:bg-muted/80",
                   )}
-                  onClick={() => setTravelMode(tm.id as any)}
+                  onClick={() => setTravelMode(tm.id)}
                   aria-label={
                     isDisallowed
                       ? t("travelModeUnavailableFor", {
@@ -616,15 +621,23 @@ export default function RoutePlanContent() {
           </span>
           <div className="flex gap-1 bg-muted/30 p-1 rounded-2xl w-full overflow-x-auto no-scrollbar">
             {[
-              { id: "normal", icon: User, label: t("normalMode", "一般") },
               {
-                id: "wheelchair",
+                id: "normal" as const,
+                icon: User,
+                label: t("normalMode", "一般"),
+              },
+              {
+                id: "wheelchair" as const,
                 icon: Accessibility,
                 label: t("wheelchairMode", "輪椅"),
               },
-              { id: "elderly", icon: User, label: t("elderlyMode", "長者") },
               {
-                id: "visual_impaired",
+                id: "elderly" as const,
+                icon: User,
+                label: t("elderlyMode", "長者"),
+              },
+              {
+                id: "visual_impaired" as const,
                 icon: EyeOff,
                 label: t("visualImpairedMode", "視障"),
               },
@@ -641,7 +654,7 @@ export default function RoutePlanContent() {
                 )}
                 onClick={() => {
                   userPickedModeRef.current = true;
-                  setA11yMode(am.id as any);
+                  setA11yMode(am.id);
                 }}
                 aria-label={am.label}
               >

--- a/src/components/BottomSheet/StationDetailContent.tsx
+++ b/src/components/BottomSheet/StationDetailContent.tsx
@@ -52,7 +52,7 @@ export default function StationDetailContent() {
     for (const m of nearbyMetro) {
       const exit = m.出入口編號 || "其他";
       if (!groups.has(exit)) groups.set(exit, []);
-      groups.get(exit)!.push(m);
+      groups.get(exit)?.push(m);
     }
     return Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b));
   }, [nearbyMetro]);

--- a/src/components/Input/PlanInput.tsx
+++ b/src/components/Input/PlanInput.tsx
@@ -147,10 +147,18 @@ export default function RoutePlanInput() {
         {/* Transportation Mode */}
         <div className="flex gap-1 bg-muted/30 p-1 rounded-2xl w-fit">
           {[
-            { id: "transit", icon: Bus, label: t("transit", "大眾運輸") },
-            { id: "drive", icon: Car, label: t("drive", "開車") },
-            { id: "motorcycle", icon: Bike, label: t("motorcycle", "機車") },
-            { id: "walk", icon: Footprints, label: t("walk", "步行") },
+            {
+              id: "transit" as const,
+              icon: Bus,
+              label: t("transit", "大眾運輸"),
+            },
+            { id: "drive" as const, icon: Car, label: t("drive", "開車") },
+            {
+              id: "motorcycle" as const,
+              icon: Bike,
+              label: t("motorcycle", "機車"),
+            },
+            { id: "walk" as const, icon: Footprints, label: t("walk", "步行") },
           ].map((tm) => (
             <Button
               key={tm.id}
@@ -162,7 +170,7 @@ export default function RoutePlanInput() {
                   ? "shadow-sm"
                   : "text-muted-foreground hover:bg-muted/80",
               )}
-              onClick={() => setTravelMode(tm.id as any)}
+              onClick={() => setTravelMode(tm.id)}
               aria-label={tm.label}
             >
               <tm.icon className="h-4 w-4" />
@@ -174,15 +182,23 @@ export default function RoutePlanInput() {
         {/* Accessibility Mode */}
         <div className="flex gap-1 bg-muted/30 p-1 rounded-2xl w-fit">
           {[
-            { id: "normal", icon: User, label: t("normalMode", "一般") },
             {
-              id: "wheelchair",
+              id: "normal" as const,
+              icon: User,
+              label: t("normalMode", "一般"),
+            },
+            {
+              id: "wheelchair" as const,
               icon: Accessibility,
               label: t("wheelchairMode", "輪椅"),
             },
-            { id: "elderly", icon: User, label: t("elderlyMode", "長者") },
             {
-              id: "visual_impaired",
+              id: "elderly" as const,
+              icon: User,
+              label: t("elderlyMode", "長者"),
+            },
+            {
+              id: "visual_impaired" as const,
               icon: EyeOff,
               label: t("visualImpairedMode", "視障"),
             },
@@ -197,7 +213,7 @@ export default function RoutePlanInput() {
                   ? "shadow-sm"
                   : "text-muted-foreground hover:bg-muted/80",
               )}
-              onClick={() => setA11yMode(am.id as any)}
+              onClick={() => setA11yMode(am.id)}
               aria-label={am.label}
             >
               <am.icon className="h-4 w-4" />

--- a/src/components/Navigation/NavigationHUD.tsx
+++ b/src/components/Navigation/NavigationHUD.tsx
@@ -38,12 +38,12 @@ import {
   type NavInstruction,
   type SlimOsmA11y,
 } from "@/types/route";
-import RecalculateOverlay from "./RecalculateOverlay";
-import type { RecalculateContext } from "./RecalculateOverlay";
 import {
   TriangleAlertIcon,
   type TriangleAlertIconHandle,
 } from "../ui/triangle-alert-icon";
+import type { RecalculateContext } from "./RecalculateOverlay";
+import RecalculateOverlay from "./RecalculateOverlay";
 
 const FACILITY_ALERT_M = 250;
 const HAZARD_ALERT_M = 200;
@@ -59,7 +59,12 @@ function AlertPulseIcon() {
     ref.current?.startAnimation();
   }, []);
   return (
-    <TriangleAlertIcon ref={ref} size={20} className="shrink-0" isAnimated={false} />
+    <TriangleAlertIcon
+      ref={ref}
+      size={20}
+      className="shrink-0"
+      isAnimated={false}
+    />
   );
 }
 
@@ -302,7 +307,7 @@ export default function NavigationHUD() {
     void Promise.all([minTimer, routePromise]).then(() =>
       setRecalcOverlay(false),
     );
-  }, [destination, handleComputeRoute, t]);
+  }, [destination, handleComputeRoute, t, recalcOverlay]);
 
   useEffect(() => {
     return () => {
@@ -363,11 +368,18 @@ export default function NavigationHUD() {
               </div>
               <div className="flex-1 min-w-0">
                 {distanceToNextM != null && (
-                  <p className="text-5xl font-black leading-none mb-2 tabular-nums tracking-tight" aria-hidden="true">
+                  <p
+                    className="text-5xl font-black leading-none mb-2 tabular-nums tracking-tight"
+                    aria-hidden="true"
+                  >
                     {formatDistance(distanceToNextM)}
                   </p>
                 )}
-                <p aria-live="assertive" aria-atomic="true" className="text-base font-medium leading-snug text-white/90 line-clamp-2">
+                <p
+                  aria-live="assertive"
+                  aria-atomic="true"
+                  className="text-base font-medium leading-snug text-white/90 line-clamp-2"
+                >
                   {step?.text ?? t("preparingNav")}
                 </p>
               </div>
@@ -396,7 +408,10 @@ export default function NavigationHUD() {
 
         {/* Off-route strip */}
         {isOffRoute && !arrived && (
-          <div role="alert" className="flex items-center gap-3 p-3 rounded-2xl bg-amber-500/95 text-white shadow-lg">
+          <div
+            role="alert"
+            className="flex items-center gap-3 p-3 rounded-2xl bg-amber-500/95 text-white shadow-lg"
+          >
             <AlertPulseIcon />
             <p className="flex-1 text-sm font-semibold">{t("offRoute")}</p>
             <button

--- a/src/components/Polyline.tsx
+++ b/src/components/Polyline.tsx
@@ -1,6 +1,6 @@
 "use client";
-import { Layer, Source } from "react-map-gl/maplibre";
 import type { LineLayerSpecification } from "maplibre-gl";
+import { Layer, Source } from "react-map-gl/maplibre";
 
 type PolylineProps = {
   id: string;

--- a/src/components/Sos/SosDialog.tsx
+++ b/src/components/Sos/SosDialog.tsx
@@ -564,9 +564,9 @@ export default function SosDialog({
                     </button>
                     {timelineExpanded && (
                       <ol className="mt-2 space-y-1.5">
-                        {timeline.map((entry, i) => (
+                        {timeline.map((entry) => (
                           <li
-                            key={`${entry.type}-${entry.at}-${i}`}
+                            key={`${entry.type}-${entry.at}-${entry.actorName ?? ""}-${entry.note ?? ""}`}
                             className="flex items-start gap-2 text-xs"
                           >
                             <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-red-500/60" />

--- a/src/components/Wrapper/A11yFacilitiesWrapper.tsx
+++ b/src/components/Wrapper/A11yFacilitiesWrapper.tsx
@@ -90,17 +90,15 @@ export default function A11yFacilitiesWrapper() {
     return () => controller.abort();
   }, [setA11yPlaces, t]);
 
-  const updateBounds = () => {
-    if (!map) return;
-    const b = map.getBounds();
-    if (b) {
-      setBounds([b.getWest(), b.getSouth(), b.getEast(), b.getNorth()]);
-      setZoom(map.getZoom());
-    }
-  };
-
   useEffect(() => {
     if (!map) return;
+    const updateBounds = () => {
+      const b = map.getBounds();
+      if (b) {
+        setBounds([b.getWest(), b.getSouth(), b.getEast(), b.getNorth()]);
+        setZoom(map.getZoom());
+      }
+    };
     updateBounds();
     map.on("move", updateBounds);
     map.on("zoom", updateBounds);
@@ -160,8 +158,13 @@ export default function A11yFacilitiesWrapper() {
       )}
       {clusters.map((cluster) => {
         const [longitude, latitude] = cluster.geometry.coordinates;
-        const properties = cluster.properties as any;
-        const { cluster: isCluster, point_count: pointCount } = properties;
+        const properties = cluster.properties as {
+          cluster?: boolean;
+          point_count?: number;
+          placeId?: string;
+          place?: MarkerType;
+        };
+        const { cluster: isCluster, point_count: pointCount = 0 } = properties;
 
         if (isCluster) {
           const size = Math.min(30 + (pointCount / points.length) * 40, 60);

--- a/src/components/layout/client-layout.tsx
+++ b/src/components/layout/client-layout.tsx
@@ -175,12 +175,7 @@ export default function ClientLayout({
   return (
     <div className="w-full h-dvh flex flex-col">
       <SkipNavLink />
-      <main
-        id="main-map"
-        className="flex-1 relative"
-        role="main"
-        aria-label="Map"
-      >
+      <main id="main-map" className="flex-1 relative" aria-label="Map">
         {children}
       </main>
       <BottomSheet />

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+import React, { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+export interface ErrorBoundaryFallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Custom fallback ReactNode or a render function receiving error and reset callback */
+  fallback?: ReactNode | ((props: ErrorBoundaryFallbackProps) => ReactNode);
+  /** Optional custom title for the default fallback card */
+  fallbackTitle?: string;
+  /** Optional custom description for the default fallback card */
+  fallbackDescription?: string;
+  /** Callback fired when the error boundary resets */
+  onReset?: () => void;
+  /** Callback fired when an error is caught */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /** Additional container classes */
+  className?: string;
+  /** Whether to show technical error details/stack */
+  showDetails?: boolean;
+}
+
+export interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+interface DefaultFallbackViewProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+  title?: string;
+  description?: string;
+  className?: string;
+  showDetails?: boolean;
+}
+
+export function DefaultErrorFallback({
+  error,
+  resetErrorBoundary,
+  title = "此區塊載入失敗",
+  description = "這個元件遇到問題無法正常顯示，請嘗試重新載入。",
+  className,
+  showDetails = false,
+}: DefaultFallbackViewProps) {
+  const isDev = process.env.NODE_ENV !== "production";
+  const shouldShowDetails = showDetails || isDev;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
+      className={cn("w-full p-4 flex items-center justify-center", className)}
+    >
+      <Card className="w-full max-w-md border-destructive/20 bg-card shadow-sm text-center">
+        <CardHeader className="pb-3">
+          <div
+            className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10 text-destructive"
+            aria-hidden="true"
+          >
+            <AlertTriangle className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-base font-semibold text-foreground">
+            {title}
+          </CardTitle>
+          {description && (
+            <CardDescription className="text-xs text-muted-foreground">
+              {description}
+            </CardDescription>
+          )}
+        </CardHeader>
+
+        {shouldShowDetails && error?.message && (
+          <CardContent className="pt-0 pb-3 text-left">
+            <details className="text-xs text-muted-foreground group">
+              <summary className="cursor-pointer font-medium hover:text-foreground select-none flex items-center gap-1">
+                <span>詳細錯誤資訊</span>
+              </summary>
+              <pre className="mt-2 max-h-32 overflow-auto rounded bg-muted/80 p-2 font-mono text-[11px] leading-relaxed text-foreground whitespace-pre-wrap break-all border border-border">
+                {error.message}
+                {error.stack ? `\n\n${error.stack}` : ""}
+              </pre>
+            </details>
+          </CardContent>
+        )}
+
+        <CardFooter className="pt-0 flex justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            onClick={resetErrorBoundary}
+            className="min-h-[44px] min-w-[44px] gap-2 font-medium hover:bg-destructive/10 hover:text-destructive hover:border-destructive/30"
+            aria-label="重新嘗試載入此區塊"
+          >
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+            <span>重新嘗試</span>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    if (this.props.onError) {
+      this.props.onError(error, errorInfo);
+    } else {
+      console.error(
+        "[ErrorBoundary] Caught unhandled component error:",
+        error,
+        errorInfo,
+      );
+    }
+  }
+
+  resetErrorBoundary = (): void => {
+    if (this.props.onReset) {
+      this.props.onReset();
+    }
+    this.setState({
+      hasError: false,
+      error: null,
+    });
+  };
+
+  render(): ReactNode {
+    const { hasError, error } = this.state;
+    const {
+      children,
+      fallback,
+      fallbackTitle,
+      fallbackDescription,
+      className,
+      showDetails,
+    } = this.props;
+
+    if (hasError && error) {
+      if (typeof fallback === "function") {
+        return fallback({
+          error,
+          resetErrorBoundary: this.resetErrorBoundary,
+        });
+      }
+
+      if (fallback) {
+        return fallback;
+      }
+
+      return (
+        <DefaultErrorFallback
+          error={error}
+          resetErrorBoundary={this.resetErrorBoundary}
+          title={fallbackTitle}
+          description={fallbackDescription}
+          className={className}
+          showDetails={showDetails}
+        />
+      );
+    }
+
+    return children;
+  }
+}
+
+/**
+ * Higher-order component to wrap any component with an ErrorBoundary
+ */
+export function withErrorBoundary<P extends object>(
+  ComponentToWrap: React.ComponentType<P>,
+  errorBoundaryProps?: Omit<ErrorBoundaryProps, "children">,
+): React.FC<P> {
+  const WrappedComponent: React.FC<P> = (props) => (
+    <ErrorBoundary {...errorBoundaryProps}>
+      <ComponentToWrap {...props} />
+    </ErrorBoundary>
+  );
+
+  const displayName =
+    ComponentToWrap.displayName || ComponentToWrap.name || "Component";
+  WrappedComponent.displayName = `withErrorBoundary(${displayName})`;
+
+  return WrappedComponent;
+}
+
+export default ErrorBoundary;

--- a/src/components/shared/HelpDialog.tsx
+++ b/src/components/shared/HelpDialog.tsx
@@ -289,10 +289,10 @@ export default function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
                   type="multiple"
                   className="rounded-xl border border-border/60 bg-card/50 overflow-hidden"
                 >
-                  {faqItems.map((item, i) => (
+                  {faqItems.map((item) => (
                     <AccordionItem
-                      key={i}
-                      value={`faq-${i}`}
+                      key={item.question}
+                      value={item.question}
                       className="border-border/40"
                     >
                       <AccordionTrigger className="px-4 py-3 text-sm font-medium text-primary hover:no-underline hover:bg-accent/30">

--- a/src/components/shared/KeyboardShortcuts.tsx
+++ b/src/components/shared/KeyboardShortcuts.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Keyboard, X } from "lucide-react";
-import { motion, AnimatePresence } from "motion/react";
+import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useState } from "react";
 import { useAppTranslation } from "@/i18n/client";
 

--- a/src/components/shared/PlaceInput.tsx
+++ b/src/components/shared/PlaceInput.tsx
@@ -32,7 +32,7 @@ import { useAppTranslation } from "@/i18n/client";
 import { getPlaceAutocomplete, getPlaceDetails } from "@/lib/api/placeSearch";
 import { toApiLang } from "@/lib/place/lang";
 import { cn } from "@/lib/utils";
-import useMapStore from "@/stores/useMapStore";
+import useMapStore, { placeKey } from "@/stores/useMapStore";
 import type { PlaceDetail } from "@/types";
 import type { AutocompleteItem, PlaceResult } from "@/types/place";
 import { formatDistance } from "@/types/route";
@@ -414,7 +414,7 @@ function PlaceInput({
                       <span className="text-base font-medium">你的位置</span>
                     </span>
                   </CommandItem>
-                  {searchHistory.map((history, idx) => {
+                  {searchHistory.map((history) => {
                     if (history.kind === "place") {
                       const { place } = history;
                       return (
@@ -423,7 +423,7 @@ function PlaceInput({
                           onSelect={() => {
                             handleHistoryClick(history);
                           }}
-                          key={`${place.id}-${idx}`}
+                          key={placeKey(history)}
                           className="flex items-start gap-3 rounded-3xl p-2 cursor-pointer transition-colors"
                         >
                           <div className="mt-1 h-8 w-8 rounded-full bg-muted flex items-center justify-center shrink-0">

--- a/src/components/shared/RouteCard.tsx
+++ b/src/components/shared/RouteCard.tsx
@@ -223,9 +223,9 @@ function IntermediateStops({
       >
         <div className="overflow-hidden">
           <div className="pl-3.5 my-2 space-y-2 border-l border-muted-foreground/30 ml-3.5">
-            {stops.map((stop, idx) => (
+            {stops.map((stop) => (
               <div
-                key={`${stop.stationUid || stop.name}-${idx}`}
+                key={stop.stationUid || stop.name}
                 className="flex items-center gap-2.5 text-xs text-muted-foreground relative"
               >
                 <div
@@ -514,9 +514,9 @@ function WalkStepsList({ steps }: { steps?: WalkStep[] }) {
       >
         <div className="overflow-hidden">
           <ul className="pl-3.5 my-2 space-y-1.5 border-l border-muted-foreground/30 ml-3.5">
-            {steps.map((step, idx) => (
+            {steps.map((step) => (
               <li
-                key={`${step.streetName || step.instruction || "step"}-${idx}`}
+                key={`${step.instruction || step.streetName || "step"}-${step.distanceM ?? 0}`}
                 className="text-xs text-muted-foreground"
               >
                 <span className="text-foreground">
@@ -570,9 +570,9 @@ function DriveStepsList({ steps }: { steps?: DriveStep[] }) {
       >
         <div className="overflow-hidden">
           <ul className="pl-3.5 my-2 space-y-1.5 border-l border-muted-foreground/30 ml-3.5">
-            {steps.map((step, idx) => (
+            {steps.map((step) => (
               <li
-                key={`${step.instruction || "step"}-${idx}`}
+                key={`${step.instruction || "step"}-${step.distanceM ?? 0}-${step.durationMin ?? 0}`}
                 className="text-xs text-muted-foreground"
               >
                 <span className="text-foreground">{step.instruction}</span>
@@ -804,13 +804,13 @@ function StarRating({
 }) {
   return (
     <span className="inline-flex gap-0.5" role="img" aria-label={ariaLabel}>
-      {Array.from({ length: 5 }, (_, i) => (
+      {[1, 2, 3, 4, 5].map((star) => (
         <svg
-          key={i}
+          key={star}
           viewBox="0 0 20 20"
           className={cn(
             "h-4 w-4",
-            i < filled ? colorClass : "text-muted-foreground/25",
+            star <= filled ? colorClass : "text-muted-foreground/25",
           )}
           aria-hidden
         >
@@ -822,6 +822,26 @@ function StarRating({
       ))}
     </span>
   );
+}
+
+function getLegKey(leg: RouteLeg): string {
+  switch (leg.type) {
+    case "WALK":
+      return `walk-${leg.from}-${leg.to}-${leg.distanceM}`;
+    case "BUS":
+      return `bus-${leg.routeName}-${leg.departureStop}-${leg.arrivalStop}`;
+    case "METRO":
+      return `metro-${leg.lineName}-${leg.departureStation}-${leg.arrivalStation}`;
+    case "THSR":
+      return `thsr-${leg.trainNo}-${leg.departureStation}-${leg.arrivalStation}`;
+    case "TRA":
+      return `tra-${leg.trainNo}-${leg.departureStation}-${leg.arrivalStation}`;
+    case "DRIVE":
+    case "MOTORCYCLE":
+      return `drive-${leg.from}-${leg.to}-${leg.distanceM}`;
+    default:
+      return `leg-${(leg as { type: string }).type}`;
+  }
 }
 
 export const RouteCard = memo(function RouteCard({
@@ -898,8 +918,9 @@ export const RouteCard = memo(function RouteCard({
             return (
               l.label ?? (l.type === "DRIVE" ? t("drive") : t("motorcycle"))
             );
+          default:
+            return "";
         }
-        return "";
       });
     return types.join(" → ");
   }, [route.legs, t]);
@@ -1034,7 +1055,7 @@ export const RouteCard = memo(function RouteCard({
             {route.legs.map((leg, index) => {
               const color = getLegColor(leg);
               return (
-                <div key={`${leg.type}-${index}`} className="relative pl-8">
+                <div key={getLegKey(leg)} className="relative pl-8">
                   {index !== route.legs.length - 1 && (
                     <div
                       className="absolute left-3.5 top-11 bottom-0 w-0.5 rounded-full"

--- a/src/components/shared/SearchPin.tsx
+++ b/src/components/shared/SearchPin.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef } from "react";
 import { Marker } from "react-map-gl/maplibre";
 import { useShallow } from "zustand/react/shallow";
-import { MapPinIcon, type MapPinIconHandle } from "@/components/ui/map-pin-icon";
+import {
+  MapPinIcon,
+  type MapPinIconHandle,
+} from "@/components/ui/map-pin-icon";
 import useMapStore from "@/stores/useMapStore";
 import type { PlaceDetail } from "@/types";
 
@@ -39,9 +42,13 @@ export default function SearchPin({
   }, [map, setInfoShow, destination]);
 
   const iconRef = useRef<MapPinIconHandle>(null);
+  const destLat = destination?.position.lat;
+  const destLng = destination?.position.lng;
   useEffect(() => {
-    iconRef.current?.startAnimation();
-  }, [destination?.position.lat, destination?.position.lng]);
+    if (destLat !== undefined && destLng !== undefined) {
+      iconRef.current?.startAnimation();
+    }
+  }, [destLat, destLng]);
 
   if (!destination) return null;
 

--- a/src/components/shared/StatusPage.tsx
+++ b/src/components/shared/StatusPage.tsx
@@ -145,7 +145,12 @@ export default function StatusPage({
   const Icon = icon ?? config.Icon;
 
   return (
-    <div className="flex min-h-dvh w-full items-center justify-center p-6">
+    <div
+      role={status === "error" ? "alert" : undefined}
+      aria-live={status === "error" ? "assertive" : undefined}
+      aria-atomic={status === "error" ? "true" : undefined}
+      className="flex min-h-dvh w-full items-center justify-center p-6"
+    >
       <Card className={cn("w-full max-w-md text-center", className)}>
         <CardHeader>
           {!hideIcon && (

--- a/src/components/shared/TransitAlerts.tsx
+++ b/src/components/shared/TransitAlerts.tsx
@@ -12,8 +12,8 @@ import { useAppTranslation } from "@/i18n/client";
 import { cn } from "@/lib/utils";
 import type { MetroAlertResult } from "@/types/route";
 import type {
-  MatchKind,
   MatchedAlert,
+  MatchKind,
   MetroAlert,
   TransitAlert,
 } from "@/types/transit-alert";

--- a/src/components/shared/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/shared/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,211 @@
+import type React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DefaultErrorFallback,
+  ErrorBoundary,
+  withErrorBoundary,
+} from "../ErrorBoundary";
+
+// A component that can conditionally throw
+function ProblematicChild({ shouldThrow = false }: { shouldThrow?: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test component crash!");
+  }
+  return <div data-testid="child-content">正常運作的元件內容</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children normally when no error occurs", () => {
+    const html = renderToStaticMarkup(
+      <ErrorBoundary>
+        <ProblematicChild shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(html).toContain("正常運作的元件內容");
+    expect(html).not.toContain("此區塊載入失敗");
+  });
+
+  it("getDerivedStateFromError updates state to hasError: true", () => {
+    const testError = new Error("Custom crash message");
+    const derived = ErrorBoundary.getDerivedStateFromError(testError);
+
+    expect(derived).toEqual({
+      hasError: true,
+      error: testError,
+    });
+  });
+
+  it("renders DefaultErrorFallback with accessible attributes when state has error", () => {
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+    });
+
+    const testError = new Error("WebGL context lost");
+    boundary.state = {
+      hasError: true,
+      error: testError,
+    };
+
+    const rendered = boundary.render();
+    const html = renderToStaticMarkup(rendered as React.ReactElement);
+
+    // Verify accessibility attributes (WCAG 2.1 AA)
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('aria-live="assertive"');
+    expect(html).toContain('aria-atomic="true"');
+    expect(html).toContain("此區塊載入失敗");
+    expect(html).toContain("這個元件遇到問題無法正常顯示，請嘗試重新載入。");
+    expect(html).toContain("重新嘗試");
+    expect(html).toContain('aria-label="重新嘗試載入此區塊"');
+  });
+
+  it("supports custom fallbackTitle and fallbackDescription", () => {
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+      fallbackTitle: "地圖圖層載入失敗",
+      fallbackDescription: "無法載入即時通阻資訊，請重新整理。",
+    });
+
+    boundary.state = {
+      hasError: true,
+      error: new Error("Failed to fetch tiles"),
+    };
+
+    const html = renderToStaticMarkup(boundary.render() as React.ReactElement);
+
+    expect(html).toContain("地圖圖層載入失敗");
+    expect(html).toContain("無法載入即時通阻資訊，請重新整理。");
+  });
+
+  it("renders a custom ReactNode fallback when provided", () => {
+    const customFallbackNode = (
+      <div role="alert" className="custom-fallback">
+        自訂錯誤提示區塊
+      </div>
+    );
+
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+      fallback: customFallbackNode,
+    });
+
+    boundary.state = {
+      hasError: true,
+      error: new Error("Custom error"),
+    };
+
+    const html = renderToStaticMarkup(boundary.render() as React.ReactElement);
+
+    expect(html).toContain("自訂錯誤提示區塊");
+    expect(html).toContain("custom-fallback");
+  });
+
+  it("renders a custom function fallback receiving error and reset callback", () => {
+    const customFallbackFn = vi.fn(({ error, resetErrorBoundary }) => (
+      <div role="alert">
+        <p>自訂函式錯誤: {error.message}</p>
+        <button type="button" onClick={resetErrorBoundary}>
+          重設
+        </button>
+      </div>
+    ));
+
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+      fallback: customFallbackFn,
+    });
+
+    const testError = new Error("Dynamic error");
+    boundary.state = {
+      hasError: true,
+      error: testError,
+    };
+
+    const html = renderToStaticMarkup(boundary.render() as React.ReactElement);
+
+    expect(customFallbackFn).toHaveBeenCalledTimes(1);
+    expect(customFallbackFn).toHaveBeenCalledWith({
+      error: testError,
+      resetErrorBoundary: boundary.resetErrorBoundary,
+    });
+    expect(html).toContain("自訂函式錯誤: Dynamic error");
+    expect(html).toContain("重設");
+  });
+
+  it("calls onReset callback and resets state when resetErrorBoundary is triggered", () => {
+    const onResetMock = vi.fn();
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+      onReset: onResetMock,
+    });
+
+    boundary.state = {
+      hasError: true,
+      error: new Error("Temporary crash"),
+    };
+
+    const setStateSpy = vi.spyOn(boundary, "setState");
+
+    boundary.resetErrorBoundary();
+
+    expect(onResetMock).toHaveBeenCalledTimes(1);
+    expect(setStateSpy).toHaveBeenCalledWith({
+      hasError: false,
+      error: null,
+    });
+  });
+
+  it("calls onError callback in componentDidCatch", () => {
+    const onErrorMock = vi.fn();
+    const boundary = new ErrorBoundary({
+      children: <div>Child</div>,
+      onError: onErrorMock,
+    });
+
+    const testError = new Error("Voice stream error");
+    const errorInfo: React.ErrorInfo = {
+      componentStack: "\n    in ProblematicChild\n    in ErrorBoundary",
+    };
+
+    boundary.componentDidCatch(testError, errorInfo);
+
+    expect(onErrorMock).toHaveBeenCalledTimes(1);
+    expect(onErrorMock).toHaveBeenCalledWith(testError, errorInfo);
+  });
+
+  it("DefaultErrorFallback displays error details when showDetails is true", () => {
+    const testError = new Error("Network timeout: 504 Gateway");
+    testError.stack = "Error: Network timeout\n    at fetchData (api.ts:42)";
+
+    const html = renderToStaticMarkup(
+      <DefaultErrorFallback
+        error={testError}
+        resetErrorBoundary={vi.fn()}
+        showDetails={true}
+      />,
+    );
+
+    expect(html).toContain("詳細錯誤資訊");
+    expect(html).toContain("Network timeout: 504 Gateway");
+  });
+});
+
+describe("withErrorBoundary HOC", () => {
+  it("wraps a component and sets displayName", () => {
+    function TestWidget({ text }: { text: string }) {
+      return <span>Widget: {text}</span>;
+    }
+    TestWidget.displayName = "TestWidget";
+
+    const Wrapped = withErrorBoundary(TestWidget, {
+      fallbackTitle: "Widget Error",
+    });
+
+    expect(Wrapped.displayName).toBe("withErrorBoundary(TestWidget)");
+
+    const html = renderToStaticMarkup(<Wrapped text="Hello" />);
+    expect(html).toContain("Widget: Hello");
+  });
+});

--- a/src/components/shared/__tests__/ErrorPages.test.tsx
+++ b/src/components/shared/__tests__/ErrorPages.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import ErrorPage from "@/app/[lng]/error";
+import GlobalError from "@/app/global-error";
+
+// Mock next/navigation for App Router
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/zh-TW/some-page",
+  redirect: vi.fn(),
+}));
+
+describe("Route ErrorPage ([lng]/error.tsx)", () => {
+  it("renders status page error layout with accessible role and title", () => {
+    const error = new Error("Failed to load transit data") as Error & {
+      digest?: string;
+    };
+    error.digest = "TRANSIT_500";
+    const resetMock = vi.fn();
+
+    const html = renderToStaticMarkup(
+      <ErrorPage error={error} reset={resetMock} />,
+    );
+
+    // Verify accessibility and error status
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('aria-live="assertive"');
+    expect(html).toContain('aria-atomic="true"');
+    expect(html).toContain("發生未預期錯誤");
+    expect(html).toContain("重新嘗試");
+    expect(html).toContain("返回首頁");
+    expect(html).toContain("TRANSIT_500");
+    expect(html).toContain("詳細錯誤資訊");
+    expect(html).toContain("Failed to load transit data");
+  });
+});
+
+describe("GlobalError (global-error.tsx)", () => {
+  it("renders complete html and body document with accessible alert layout", () => {
+    const error = new Error("Fatal root layout failure") as Error & {
+      digest?: string;
+    };
+    error.digest = "ROOT_PANIC_999";
+    const resetMock = vi.fn();
+
+    const html = renderToStaticMarkup(
+      <GlobalError error={error} reset={resetMock} />,
+    );
+
+    // Verify complete HTML document structure
+    expect(html).toContain("<html");
+    expect(html).toContain('lang="zh-TW"');
+    expect(html).toContain("<body");
+    expect(html).toContain("<main");
+    expect(html).toContain('role="alert"');
+    expect(html).toContain('aria-live="assertive"');
+    expect(html).toContain('aria-atomic="true"');
+    expect(html).toContain("系統發生重大錯誤");
+    expect(html).toContain(
+      "應用程式核心元件發生未預期的錯誤，請嘗試重新載入整個頁面或返回首頁。",
+    );
+    expect(html).toContain("ROOT_PANIC_999");
+    expect(html).toContain("重新載入頁面");
+    expect(html).toContain("返回首頁");
+    expect(html).toContain("詳細錯誤資訊");
+    expect(html).toContain("Fatal root layout failure");
+  });
+});

--- a/src/components/shared/__tests__/RouteCard.test.ts
+++ b/src/components/shared/__tests__/RouteCard.test.ts
@@ -36,7 +36,12 @@ import {
 import { ColorEnum, FontSizeEnum, LanguageEnum } from "@/lib/config";
 import useAuthStore from "@/stores/useAuthStore";
 import useMapStore from "@/stores/useMapStore";
-import type { AccessibleRoute, SlimOsmA11y } from "@/types/route";
+import type {
+  AccessibleRoute,
+  BusLeg,
+  MetroLeg,
+  SlimOsmA11y,
+} from "@/types/route";
 
 const mockUseMapStore = vi.mocked(useMapStore);
 const mockUseAuthStore = vi.mocked(useAuthStore);
@@ -138,7 +143,7 @@ describe("getRouteAlertsCount", () => {
           matchKind: "route",
         },
       ],
-    } as any;
+    } as BusLeg;
     route.legs[2] = {
       ...route.legs[2],
       alerts: [
@@ -153,7 +158,7 @@ describe("getRouteAlertsCount", () => {
           updateTime: "",
         },
       ],
-    } as any;
+    } as MetroLeg;
 
     expect(getRouteAlertsCount(route)).toBe(2);
   });
@@ -171,7 +176,7 @@ describe("getRouteAlertsCount", () => {
           matchKind: "route",
         },
       ],
-    } as any;
+    } as BusLeg;
     route.legs[2] = {
       ...route.legs[2],
       alerts: [
@@ -186,7 +191,7 @@ describe("getRouteAlertsCount", () => {
           updateTime: "",
         },
       ],
-    } as any;
+    } as MetroLeg;
 
     expect(getRouteAlertsCount(route)).toBe(1);
   });
@@ -481,7 +486,7 @@ describe("RouteCard", () => {
           reason: "道路施工",
         },
       ],
-    } as any;
+    } as BusLeg;
     routeWithAlerts.legs[2] = {
       ...routeWithAlerts.legs[2],
       alerts: [
@@ -496,7 +501,7 @@ describe("RouteCard", () => {
           updateTime: "",
         },
       ],
-    } as any;
+    } as MetroLeg;
 
     // Scan layer (unselected): route-level warning badge is visible
     const unselectedHtml = renderRoute(routeWithAlerts, 0, false);

--- a/src/components/ui/accessibility-icon.tsx
+++ b/src/components/ui/accessibility-icon.tsx
@@ -1,163 +1,165 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import type { Variants } from "motion/react";
 import {
- LazyMotion,
- domMin,
- m,
- useAnimation,
- useReducedMotion,
+  domMin,
+  LazyMotion,
+  m,
+  useAnimation,
+  useReducedMotion,
 } from "motion/react";
 import {
- forwardRef,
- useCallback,
- useImperativeHandle,
- useRef,
- type HTMLAttributes,
+  forwardRef,
+  type HTMLAttributes,
+  useCallback,
+  useImperativeHandle,
+  useRef,
 } from "react";
+import { cn } from "@/lib/utils";
 export interface AccessibilityIconHandle {
- startAnimation: () => void;
- stopAnimation: () => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }
 
-interface AccessibilityIconProps extends Omit<
- HTMLAttributes<HTMLDivElement>,
- | "color"
- | "onDrag"
- | "onDragStart"
- | "onDragEnd"
- | "onAnimationStart"
- | "onAnimationEnd"
- | "onAnimationIteration"
-> {
- size?: number;
- duration?: number;
- isAnimated?: boolean;
- color?: string;
+interface AccessibilityIconProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    | "color"
+    | "onDrag"
+    | "onDragStart"
+    | "onDragEnd"
+    | "onAnimationStart"
+    | "onAnimationEnd"
+    | "onAnimationIteration"
+  > {
+  size?: number;
+  duration?: number;
+  isAnimated?: boolean;
+  color?: string;
 }
 
 const AccessibilityIcon = forwardRef<
- AccessibilityIconHandle,
- AccessibilityIconProps
+  AccessibilityIconHandle,
+  AccessibilityIconProps
 >(
- (
-  {
-   onMouseEnter,
-   onMouseLeave,
-   className,
-   size = 24,
-   duration = 1,
-   isAnimated = true,
-   color,
-   ...props
+  (
+    {
+      onMouseEnter,
+      onMouseLeave,
+      className,
+      size = 24,
+      duration = 1,
+      isAnimated = true,
+      color,
+      ...props
+    },
+    ref,
+  ) => {
+    const controls = useAnimation();
+    const reduced = useReducedMotion();
+    const isControlled = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlled.current = true;
+      return {
+        startAnimation: () =>
+          reduced ? controls.start("normal") : controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isAnimated || reduced) return;
+        if (!isControlled.current) controls.start("animate");
+        else onMouseEnter?.(e);
+      },
+      [controls, reduced, isAnimated, onMouseEnter],
+    );
+
+    const handleLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlled.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    const containerVariants: Variants = {
+      normal: { rotate: 0 },
+      animate: {
+        rotate: -6,
+        transition: {
+          duration: 0.35,
+          ease: "easeOut",
+        },
+      },
+    };
+
+    const wheelVariants: Variants = {
+      normal: { rotate: 0 },
+      animate: {
+        rotate: 360,
+        transition: {
+          duration: 1.4 * duration,
+          repeat: Infinity,
+          ease: "linear",
+        },
+      },
+    };
+    const handVariants: Variants = {
+      normal: { rotate: 0 },
+      animate: {
+        rotate: -25,
+        transition: {
+          duration: 0.7 * duration,
+          ease: "easeInOut",
+          repeat: Infinity,
+          repeatType: "mirror",
+        },
+      },
+    };
+
+    return (
+      <LazyMotion features={domMin} strict>
+        <m.div
+          className={cn("inline-flex items-center justify-center", className)}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          {...props}
+          style={{ color, ...props.style }}
+        >
+          <m.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            animate={controls}
+            initial="normal"
+            variants={containerVariants}
+          >
+            <circle cx="16" cy="4" r="1" />
+            <path d="m18 19 1-7-6 1" />
+            <m.path d="m5 8 3-3 5.5 3-2.36 3.5" variants={handVariants} />
+            <m.g variants={wheelVariants}>
+              <path d="M4.24 14.5a5 5 0 0 0 6.88 6" />
+              <path d="M13.76 17.5a5 5 0 0 0-6.88-6" />
+            </m.g>
+          </m.svg>
+        </m.div>
+      </LazyMotion>
+    );
   },
-  ref,
- ) => {
-  const controls = useAnimation();
-  const reduced = useReducedMotion();
-  const isControlled = useRef(false);
-
-  useImperativeHandle(ref, () => {
-   isControlled.current = true;
-   return {
-    startAnimation: () =>
-     reduced ? controls.start("normal") : controls.start("animate"),
-    stopAnimation: () => controls.start("normal"),
-   };
-  });
-
-  const handleEnter = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isAnimated || reduced) return;
-    if (!isControlled.current) controls.start("animate");
-    else onMouseEnter?.(e as any);
-   },
-   [controls, reduced, isAnimated, onMouseEnter],
-  );
-
-  const handleLeave = useCallback(
-   (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!isControlled.current) {
-     controls.start("normal");
-    } else {
-     onMouseLeave?.(e as any);
-    }
-   },
-   [controls, onMouseLeave],
-  );
-
-  const containerVariants: Variants = {
-   normal: { rotate: 0 },
-   animate: {
-    rotate: -6,
-    transition: {
-     duration: 0.35,
-     ease: "easeOut",
-    },
-   },
-  };
-
-  const wheelVariants: Variants = {
-   normal: { rotate: 0 },
-   animate: {
-    rotate: 360,
-    transition: {
-     duration: 1.4 * duration,
-     repeat: Infinity,
-     ease: "linear",
-    },
-   },
-  };
-  const handVariants: Variants = {
-   normal: { rotate: 0 },
-   animate: {
-    rotate: -25,
-    transition: {
-     duration: 0.7 * duration,
-     ease: "easeInOut",
-     repeat: Infinity,
-     repeatType: "mirror",
-    },
-   },
-  };
-
-  return (
-   <LazyMotion features={domMin} strict>
-    <m.div
-     className={cn("inline-flex items-center justify-center", className)}
-     onMouseEnter={handleEnter}
-     onMouseLeave={handleLeave}
-     {...props}
-     style={{ color, ...props.style }}
-    >
-     <m.svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      animate={controls}
-      initial="normal"
-      variants={containerVariants}
-     >
-      <circle cx="16" cy="4" r="1" />
-      <path d="m18 19 1-7-6 1" />
-      <m.path d="m5 8 3-3 5.5 3-2.36 3.5" variants={handVariants} />
-      <m.g variants={wheelVariants}>
-       <path d="M4.24 14.5a5 5 0 0 0 6.88 6" />
-       <path d="M13.76 17.5a5 5 0 0 0-6.88-6" />
-      </m.g>
-     </m.svg>
-    </m.div>
-   </LazyMotion>
-  );
- },
 );
 
 AccessibilityIcon.displayName = "AccessibilityIcon";
+
 export { AccessibilityIcon };

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -63,4 +63,4 @@ function AccordionContent({
   );
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -50,4 +50,4 @@ function AvatarFallback({
   );
 }
 
-export { Avatar, AvatarImage, AvatarFallback };
+export { Avatar, AvatarFallback, AvatarImage };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -83,10 +83,10 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
 
 export {
   Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
   CardAction,
-  CardDescription,
   CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
 };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -173,11 +173,11 @@ function CommandShortcut({
 export {
   Command,
   CommandDialog,
-  CommandInput,
-  CommandList,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
-  CommandShortcut,
+  CommandList,
   CommandSeparator,
+  CommandShortcut,
 };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -123,13 +123,13 @@ function DrawerDescription({
 
 export {
   Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
   DrawerClose,
   DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
   DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
 };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -240,18 +240,18 @@ function DropdownMenuSubContent({
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
 };

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -41,4 +41,4 @@ function HoverCardContent({
   );
 }
 
-export { HoverCard, HoverCardTrigger, HoverCardContent };
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/src/components/ui/map-pin-icon.tsx
+++ b/src/components/ui/map-pin-icon.tsx
@@ -1,160 +1,163 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import type { Variants } from "motion/react";
 import {
- LazyMotion,
- domMin,
- m,
- useAnimation,
- useReducedMotion,
+  domMin,
+  LazyMotion,
+  m,
+  useAnimation,
+  useReducedMotion,
 } from "motion/react";
 import {
- forwardRef,
- useCallback,
- useImperativeHandle,
- useRef,
- type HTMLAttributes,
+  forwardRef,
+  type HTMLAttributes,
+  useCallback,
+  useImperativeHandle,
+  useRef,
 } from "react";
+import { cn } from "@/lib/utils";
 export interface MapPinIconHandle {
- startAnimation: () => void;
- stopAnimation: () => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }
 
-interface MapPinIconProps extends Omit<
- HTMLAttributes<HTMLDivElement>,
- | "color"
- | "onDrag"
- | "onDragStart"
- | "onDragEnd"
- | "onAnimationStart"
- | "onAnimationEnd"
- | "onAnimationIteration"
-> {
- size?: number;
- duration?: number;
- isAnimated?: boolean;
- color?: string;
+interface MapPinIconProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    | "color"
+    | "onDrag"
+    | "onDragStart"
+    | "onDragEnd"
+    | "onAnimationStart"
+    | "onAnimationEnd"
+    | "onAnimationIteration"
+  > {
+  size?: number;
+  duration?: number;
+  isAnimated?: boolean;
+  color?: string;
 }
 
 const MapPinIcon = forwardRef<MapPinIconHandle, MapPinIconProps>(
- (
-  {
-   onMouseEnter,
-   onMouseLeave,
-   className,
-   size = 24,
-   duration = 1,
-   isAnimated = true,
-   color,
-   ...props
+  (
+    {
+      onMouseEnter,
+      onMouseLeave,
+      className,
+      size = 24,
+      duration = 1,
+      isAnimated = true,
+      color,
+      ...props
+    },
+    ref,
+  ) => {
+    const pathControls = useAnimation();
+    const circleControls = useAnimation();
+    const reduced = useReducedMotion();
+    const isControlled = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlled.current = true;
+      return {
+        startAnimation: () => {
+          if (reduced) {
+            pathControls.start("normal");
+            circleControls.start("normal");
+          } else {
+            pathControls.start("animate");
+            circleControls.start("animate");
+          }
+        },
+        stopAnimation: () => {
+          pathControls.start("normal");
+          circleControls.start("normal");
+        },
+      };
+    });
+
+    const handleEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isAnimated || reduced) return;
+        if (!isControlled.current) {
+          pathControls.start("animate");
+          circleControls.start("animate");
+        } else onMouseEnter?.(e);
+      },
+      [pathControls, circleControls, reduced, onMouseEnter, isAnimated],
+    );
+
+    const handleLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlled.current) {
+          pathControls.start("normal");
+          circleControls.start("normal");
+        } else onMouseLeave?.(e);
+      },
+      [pathControls, circleControls, onMouseLeave],
+    );
+
+    const pathVariants: Variants = {
+      normal: { strokeDashoffset: 0, scale: 1 },
+      animate: {
+        strokeDashoffset: [120, 0],
+        scale: [1, 1.05, 1],
+        transition: { duration: 1.5 * duration, ease: "easeOut" },
+      },
+    };
+
+    const circleVariants: Variants = {
+      normal: { scale: 1, opacity: 1 },
+      animate: {
+        scale: [1, 1.2, 1],
+        opacity: [1, 0.7, 1],
+        transition: { duration: 0.9 * duration, ease: "easeOut", delay: 0.2 },
+      },
+    };
+    return (
+      <LazyMotion features={domMin} strict>
+        <m.div
+          className={cn("inline-flex items-center justify-center", className)}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          {...props}
+          style={{ color, ...props.style }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={className}
+          >
+            <title>Map Pin</title>
+            <m.path
+              d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
+              initial="normal"
+              animate={pathControls}
+              variants={pathVariants}
+              style={{ strokeDasharray: 120, strokeLinecap: "round" }}
+            />
+            <m.circle
+              cx="12"
+              cy="10"
+              r="3"
+              initial="normal"
+              animate={circleControls}
+              variants={circleVariants}
+            />
+          </svg>
+        </m.div>
+      </LazyMotion>
+    );
   },
-  ref,
- ) => {
-  const pathControls = useAnimation();
-  const circleControls = useAnimation();
-  const reduced = useReducedMotion();
-  const isControlled = useRef(false);
-
-  useImperativeHandle(ref, () => {
-   isControlled.current = true;
-   return {
-    startAnimation: () => {
-     if (reduced) {
-      pathControls.start("normal");
-      circleControls.start("normal");
-     } else {
-      pathControls.start("animate");
-      circleControls.start("animate");
-     }
-    },
-    stopAnimation: () => {
-     pathControls.start("normal");
-     circleControls.start("normal");
-    },
-   };
-  });
-
-  const handleEnter = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isAnimated || reduced) return;
-    if (!isControlled.current) {
-     pathControls.start("animate");
-     circleControls.start("animate");
-    } else onMouseEnter?.(e as any);
-   },
-   [pathControls, circleControls, reduced, onMouseEnter, isAnimated],
-  );
-
-  const handleLeave = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isControlled.current) {
-     pathControls.start("normal");
-     circleControls.start("normal");
-    } else onMouseLeave?.(e as any);
-   },
-   [pathControls, circleControls, onMouseLeave],
-  );
-
-  const pathVariants: Variants = {
-   normal: { strokeDashoffset: 0, scale: 1 },
-   animate: {
-    strokeDashoffset: [120, 0],
-    scale: [1, 1.05, 1],
-    transition: { duration: 1.5 * duration, ease: "easeOut" },
-   },
-  };
-
-  const circleVariants: Variants = {
-   normal: { scale: 1, opacity: 1 },
-   animate: {
-    scale: [1, 1.2, 1],
-    opacity: [1, 0.7, 1],
-    transition: { duration: 0.9 * duration, ease: "easeOut", delay: 0.2 },
-   },
-  };
-  return (
-   <LazyMotion features={domMin} strict>
-    <m.div
-     className={cn("inline-flex items-center justify-center", className)}
-     onMouseEnter={handleEnter}
-     onMouseLeave={handleLeave}
-     {...props}
-     style={{ color, ...props.style }}
-    >
-     <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-     >
-      <m.path
-       d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"
-       initial="normal"
-       animate={pathControls}
-       variants={pathVariants}
-       style={{ strokeDasharray: 120, strokeLinecap: "round" }}
-      />
-      <m.circle
-       cx="12"
-       cy="10"
-       r="3"
-       initial="normal"
-       animate={circleControls}
-       variants={circleVariants}
-      />
-     </svg>
-    </m.div>
-   </LazyMotion>
-  );
- },
 );
 
 MapPinIcon.displayName = "MapPinIcon";
+
 export { MapPinIcon };

--- a/src/components/ui/mic-icon.tsx
+++ b/src/components/ui/mic-icon.tsx
@@ -1,128 +1,130 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import type { Variants } from "motion/react";
 import {
- LazyMotion,
- domMin,
- m,
- useAnimation,
- useReducedMotion,
+  domMin,
+  LazyMotion,
+  m,
+  useAnimation,
+  useReducedMotion,
 } from "motion/react";
 import {
- forwardRef,
- useCallback,
- useImperativeHandle,
- useRef,
- type HTMLAttributes,
+  forwardRef,
+  type HTMLAttributes,
+  useCallback,
+  useImperativeHandle,
+  useRef,
 } from "react";
+import { cn } from "@/lib/utils";
 export interface MicIconHandle {
- startAnimation: () => void;
- stopAnimation: () => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }
 
-interface MicIconProps extends Omit<
- HTMLAttributes<HTMLDivElement>,
- | "color"
- | "onDrag"
- | "onDragStart"
- | "onDragEnd"
- | "onAnimationStart"
- | "onAnimationEnd"
- | "onAnimationIteration"
-> {
- size?: number;
- duration?: number;
- isAnimated?: boolean;
- color?: string;
+interface MicIconProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    | "color"
+    | "onDrag"
+    | "onDragStart"
+    | "onDragEnd"
+    | "onAnimationStart"
+    | "onAnimationEnd"
+    | "onAnimationIteration"
+  > {
+  size?: number;
+  duration?: number;
+  isAnimated?: boolean;
+  color?: string;
 }
 
 const MicIcon = forwardRef<MicIconHandle, MicIconProps>(
- (
-  {
-   onMouseEnter,
-   onMouseLeave,
-   className,
-   size = 24,
-   duration = 1,
-   isAnimated = true,
-   color,
-   ...props
+  (
+    {
+      onMouseEnter,
+      onMouseLeave,
+      className,
+      size = 24,
+      duration = 1,
+      isAnimated = true,
+      color,
+      ...props
+    },
+    ref,
+  ) => {
+    const controls = useAnimation();
+    const reduced = useReducedMotion();
+    const isControlled = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlled.current = true;
+      return {
+        startAnimation: () =>
+          reduced ? controls.start("normal") : controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isAnimated || reduced) return;
+        if (!isControlled.current) controls.start("animate");
+        else onMouseEnter?.(e);
+      },
+      [controls, reduced, isAnimated, onMouseEnter],
+    );
+
+    const handleLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlled.current) controls.start("normal");
+        else onMouseLeave?.(e);
+      },
+      [controls, onMouseLeave],
+    );
+
+    const micVariants: Variants = {
+      normal: { scale: 1, rotate: 0, y: 0 },
+      animate: {
+        scale: [1, 1.1, 0.95, 1],
+        rotate: [0, -3, 3, -2, 2, 0],
+        y: [0, -1, 0],
+        transition: { duration: 1.5 * duration, repeat: 0, ease: "easeInOut" },
+      },
+    };
+
+    return (
+      <LazyMotion features={domMin} strict>
+        <m.div
+          className={cn("inline-flex items-center justify-center", className)}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          {...props}
+          style={{ color, ...props.style }}
+        >
+          <m.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            variants={micVariants}
+            animate={controls}
+            initial="normal"
+          >
+            <path d="M12 19v3" />
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+            <rect x="9" y="2" width="6" height="13" rx="3" />
+          </m.svg>
+        </m.div>
+      </LazyMotion>
+    );
   },
-  ref,
- ) => {
-  const controls = useAnimation();
-  const reduced = useReducedMotion();
-  const isControlled = useRef(false);
-
-  useImperativeHandle(ref, () => {
-   isControlled.current = true;
-   return {
-    startAnimation: () =>
-     reduced ? controls.start("normal") : controls.start("animate"),
-    stopAnimation: () => controls.start("normal"),
-   };
-  });
-
-  const handleEnter = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isAnimated || reduced) return;
-    if (!isControlled.current) controls.start("animate");
-    else onMouseEnter?.(e as any);
-   },
-   [controls, reduced, isAnimated, onMouseEnter],
-  );
-
-  const handleLeave = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isControlled.current) controls.start("normal");
-    else onMouseLeave?.(e as any);
-   },
-   [controls, onMouseLeave],
-  );
-
-  const micVariants: Variants = {
-   normal: { scale: 1, rotate: 0, y: 0 },
-   animate: {
-    scale: [1, 1.1, 0.95, 1],
-    rotate: [0, -3, 3, -2, 2, 0],
-    y: [0, -1, 0],
-    transition: { duration: 1.5 * duration, repeat: 0, ease: "easeInOut" },
-   },
-  };
-
-  return (
-   <LazyMotion features={domMin} strict>
-    <m.div
-     className={cn("inline-flex items-center justify-center", className)}
-     onMouseEnter={handleEnter}
-     onMouseLeave={handleLeave}
-     {...props}
-     style={{ color, ...props.style }}
-    >
-     <m.svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      variants={micVariants}
-      animate={controls}
-      initial="normal"
-     >
-      <path d="M12 19v3" />
-      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-      <rect x="9" y="2" width="6" height="13" rx="3" />
-     </m.svg>
-    </m.div>
-   </LazyMotion>
-  );
- },
 );
 
 MicIcon.displayName = "MicIcon";
+
 export { MicIcon };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
+import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -45,4 +45,4 @@ function PopoverAnchor({
   return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -63,4 +63,4 @@ function TabsContent({
   );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent };
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/src/components/ui/triangle-alert-icon.tsx
+++ b/src/components/ui/triangle-alert-icon.tsx
@@ -1,185 +1,187 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import type { Variants } from "motion/react";
 import {
- LazyMotion,
- domMin,
- m,
- useAnimation,
- useReducedMotion,
+  domMin,
+  LazyMotion,
+  m,
+  useAnimation,
+  useReducedMotion,
 } from "motion/react";
 import {
- forwardRef,
- useCallback,
- useImperativeHandle,
- useRef,
- type HTMLAttributes,
+  forwardRef,
+  type HTMLAttributes,
+  useCallback,
+  useImperativeHandle,
+  useRef,
 } from "react";
+import { cn } from "@/lib/utils";
 export interface TriangleAlertIconHandle {
- startAnimation: () => void;
- stopAnimation: () => void;
+  startAnimation: () => void;
+  stopAnimation: () => void;
 }
 
-interface TriangleAlertIconProps extends Omit<
- HTMLAttributes<HTMLDivElement>,
- | "color"
- | "onDrag"
- | "onDragStart"
- | "onDragEnd"
- | "onAnimationStart"
- | "onAnimationEnd"
- | "onAnimationIteration"
-> {
- size?: number;
- duration?: number;
- isAnimated?: boolean;
- color?: string;
+interface TriangleAlertIconProps
+  extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    | "color"
+    | "onDrag"
+    | "onDragStart"
+    | "onDragEnd"
+    | "onAnimationStart"
+    | "onAnimationEnd"
+    | "onAnimationIteration"
+  > {
+  size?: number;
+  duration?: number;
+  isAnimated?: boolean;
+  color?: string;
 }
 
 const TriangleAlertIcon = forwardRef<
- TriangleAlertIconHandle,
- TriangleAlertIconProps
+  TriangleAlertIconHandle,
+  TriangleAlertIconProps
 >(
- (
-  {
-   onMouseEnter,
-   onMouseLeave,
-   className,
-   size = 24,
-   duration = 1,
-   isAnimated = true,
-   color,
-   ...props
+  (
+    {
+      onMouseEnter,
+      onMouseLeave,
+      className,
+      size = 24,
+      duration = 1,
+      isAnimated = true,
+      color,
+      ...props
+    },
+    ref,
+  ) => {
+    const controls = useAnimation();
+    const reduced = useReducedMotion();
+    const isControlled = useRef(false);
+
+    useImperativeHandle(ref, () => {
+      isControlled.current = true;
+      return {
+        startAnimation: () =>
+          reduced ? controls.start("normal") : controls.start("animate"),
+        stopAnimation: () => controls.start("normal"),
+      };
+    });
+
+    const handleEnter = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isAnimated || reduced) return;
+        if (!isControlled.current) {
+          controls.start("animate");
+        } else {
+          onMouseEnter?.(e);
+        }
+      },
+      [controls, reduced, isAnimated, onMouseEnter],
+    );
+
+    const handleLeave = useCallback(
+      (e: React.MouseEvent<HTMLDivElement>) => {
+        if (!isControlled.current) {
+          controls.start("normal");
+        } else {
+          onMouseLeave?.(e);
+        }
+      },
+      [controls, onMouseLeave],
+    );
+
+    const svgVariants: Variants = {
+      normal: { rotate: 0 },
+      animate: {
+        rotate: [0, 3, -8, 7, -5, 3, 0],
+        transition: {
+          duration: 1 * duration,
+          ease: "easeInOut",
+          times: [0, 0.1, 0.28, 0.46, 0.64, 0.82, 1],
+        },
+      },
+    };
+
+    const triangleVariants: Variants = {
+      normal: { scale: 1, opacity: 1 },
+      animate: {
+        scale: [1, 1.06, 1],
+        opacity: [0.6, 1, 1],
+        transition: {
+          duration: 1 * duration,
+          ease: "easeOut",
+          times: [0, 0.3, 1],
+        },
+      },
+    };
+
+    const lineVariants: Variants = {
+      normal: { scaleY: 1, opacity: 1 },
+      animate: {
+        scaleY: [0.3, 1.2, 0.96, 1],
+        opacity: [0, 1, 1, 1],
+        transition: {
+          duration: 0.8 * duration,
+          ease: [0.34, 1.4, 0.64, 1],
+          delay: 0.16 * duration,
+        },
+      },
+    };
+
+    const dotVariants: Variants = {
+      normal: { scale: 1, opacity: 1 },
+      animate: {
+        scale: [0, 1.6, 1],
+        opacity: [0, 1, 1],
+        transition: {
+          duration: 0.8 * duration,
+          ease: [0.34, 1.4, 0.64, 1],
+          delay: 0.3 * duration,
+        },
+      },
+    };
+
+    return (
+      <LazyMotion features={domMin} strict>
+        <m.div
+          className={cn("inline-flex items-center justify-center", className)}
+          onMouseEnter={handleEnter}
+          onMouseLeave={handleLeave}
+          {...props}
+          style={{ color, ...props.style }}
+        >
+          <m.svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            animate={controls}
+            initial="normal"
+            variants={svgVariants}
+          >
+            <m.path
+              d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              variants={triangleVariants}
+            />
+            <m.path
+              d="M12 9v4"
+              variants={lineVariants}
+              style={{ transformOrigin: "12px 13px" }}
+            />
+            <m.path d="M12 17h.01" variants={dotVariants} />
+          </m.svg>
+        </m.div>
+      </LazyMotion>
+    );
   },
-  ref,
- ) => {
-  const controls = useAnimation();
-  const reduced = useReducedMotion();
-  const isControlled = useRef(false);
-
-  useImperativeHandle(ref, () => {
-   isControlled.current = true;
-   return {
-    startAnimation: () =>
-     reduced ? controls.start("normal") : controls.start("animate"),
-    stopAnimation: () => controls.start("normal"),
-   };
-  });
-
-  const handleEnter = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isAnimated || reduced) return;
-    if (!isControlled.current) {
-     controls.start("animate");
-    } else {
-     onMouseEnter?.(e as any);
-    }
-   },
-   [controls, reduced, isAnimated, onMouseEnter],
-  );
-
-  const handleLeave = useCallback(
-   (e?: React.MouseEvent<HTMLDivElement>) => {
-    if (!isControlled.current) {
-     controls.start("normal");
-    } else {
-     onMouseLeave?.(e as any);
-    }
-   },
-   [controls, onMouseLeave],
-  );
-
-  const svgVariants: Variants = {
-   normal: { rotate: 0 },
-   animate: {
-    rotate: [0, 3, -8, 7, -5, 3, 0],
-    transition: {
-     duration: 1 * duration,
-     ease: "easeInOut",
-     times: [0, 0.1, 0.28, 0.46, 0.64, 0.82, 1],
-    },
-   },
-  };
-
-  const triangleVariants: Variants = {
-   normal: { scale: 1, opacity: 1 },
-   animate: {
-    scale: [1, 1.06, 1],
-    opacity: [0.6, 1, 1],
-    transition: {
-     duration: 1 * duration,
-     ease: "easeOut",
-     times: [0, 0.3, 1],
-    },
-   },
-  };
-
-  const lineVariants: Variants = {
-   normal: { scaleY: 1, opacity: 1 },
-   animate: {
-    scaleY: [0.3, 1.2, 0.96, 1],
-    opacity: [0, 1, 1, 1],
-    transition: {
-     duration: 0.8 * duration,
-     ease: [0.34, 1.4, 0.64, 1],
-     delay: 0.16 * duration,
-    },
-   },
-  };
-
-  const dotVariants: Variants = {
-   normal: { scale: 1, opacity: 1 },
-   animate: {
-    scale: [0, 1.6, 1],
-    opacity: [0, 1, 1],
-    transition: {
-     duration: 0.8 * duration,
-     ease: [0.34, 1.4, 0.64, 1],
-     delay: 0.3 * duration,
-    },
-   },
-  };
-
-  return (
-   <LazyMotion features={domMin} strict>
-    <m.div
-     className={cn("inline-flex items-center justify-center", className)}
-     onMouseEnter={handleEnter}
-     onMouseLeave={handleLeave}
-     {...props}
-     style={{ color, ...props.style }}
-    >
-     <m.svg
-      xmlns="http://www.w3.org/2000/svg"
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      animate={controls}
-      initial="normal"
-      variants={svgVariants}
-     >
-      <m.path
-       d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-       variants={triangleVariants}
-      />
-      <m.path
-       d="M12 9v4"
-       variants={lineVariants}
-       style={{ transformOrigin: "12px 13px" }}
-      />
-      <m.path d="M12 17h.01" variants={dotVariants} />
-     </m.svg>
-    </m.div>
-   </LazyMotion>
-  );
- },
 );
 
 TriangleAlertIcon.displayName = "TriangleAlertIcon";
+
 export { TriangleAlertIcon };

--- a/src/hook/useComputeRoute.ts
+++ b/src/hook/useComputeRoute.ts
@@ -11,6 +11,22 @@ import {
 } from "@/lib/mapCamera";
 import useMapStore from "@/stores/useMapStore";
 import type { LatLng } from "@/types";
+import type { AccessibleRoute } from "@/types/route";
+
+type CoordLike = {
+  lat?: number;
+  latitude?: number;
+  lng?: number;
+  longitude?: number;
+};
+
+function getCoordLat(c: CoordLike | undefined): number | undefined {
+  return c?.lat ?? c?.latitude;
+}
+
+function getCoordLng(c: CoordLike | undefined): number | undefined {
+  return c?.lng ?? c?.longitude;
+}
 
 // Past this, a straight-line distance is well beyond any plausible
 // domestic trip (Taipei–Kaohsiung is ~300km) and almost certainly means
@@ -126,9 +142,9 @@ export default function useComputeRoute() {
         setRouteSelect({ index: 0, route: routes[0] });
 
         const apiWaypoints: LatLng[] = (response.data.waypoints ?? [])
-          .map((w) => ({
-            lat: w.lat ?? (w as any).latitude,
-            lng: w.lng ?? (w as any).longitude,
+          .map((w: CoordLike) => ({
+            lat: getCoordLat(w) ?? 0,
+            lng: getCoordLng(w) ?? 0,
           }))
           .filter((w) => Number.isFinite(w.lat) && Number.isFinite(w.lng));
         setRouteWaypoints(apiWaypoints);
@@ -141,26 +157,24 @@ export default function useComputeRoute() {
             response.data.origin &&
             response.data.destination
           ) {
-            const oLat =
-              response.data.origin.lat ??
-              (response.data.origin as any).latitude;
-            const oLng =
-              response.data.origin.lng ??
-              (response.data.origin as any).longitude;
-            const dLat =
-              response.data.destination.lat ??
-              (response.data.destination as any).latitude;
-            const dLng =
-              response.data.destination.lng ??
-              (response.data.destination as any).longitude;
-            extendBounds(bounds, oLng, oLat);
-            extendBounds(bounds, dLng, dLat);
+            const oLat = getCoordLat(response.data.origin as CoordLike);
+            const oLng = getCoordLng(response.data.origin as CoordLike);
+            const dLat = getCoordLat(response.data.destination as CoordLike);
+            const dLng = getCoordLng(response.data.destination as CoordLike);
+            if (oLat !== undefined && oLng !== undefined) {
+              extendBounds(bounds, oLng, oLat);
+            }
+            if (dLat !== undefined && dLng !== undefined) {
+              extendBounds(bounds, dLng, dLat);
+            }
           }
 
           for (const w of response.data.waypoints ?? []) {
-            const wLat = w.lat ?? (w as any).latitude;
-            const wLng = w.lng ?? (w as any).longitude;
-            extendBounds(bounds, wLng, wLat);
+            const wLat = getCoordLat(w as CoordLike);
+            const wLng = getCoordLng(w as CoordLike);
+            if (wLat !== undefined && wLng !== undefined) {
+              extendBounds(bounds, wLng, wLat);
+            }
           }
 
           fitRouteBounds(map, bounds);
@@ -211,7 +225,11 @@ export default function useComputeRoute() {
   );
 
   const setComputedRouteData = useCallback(
-    (origin: any, destination: any, routes: any[]) => {
+    (
+      origin: CoordLike | null | undefined,
+      destination: CoordLike | null | undefined,
+      routes: AccessibleRoute[],
+    ) => {
       if (!routes?.length) return;
       setComputeRoutes(routes);
       setRouteSelect({ index: 0, route: routes[0] });
@@ -222,16 +240,16 @@ export default function useComputeRoute() {
           const bounds = routeBoundsFromLegs(routes[0].legs);
 
           if (bounds.isEmpty() && origin && destination) {
-            extendBounds(
-              bounds,
-              origin.lng ?? origin.longitude,
-              origin.lat ?? origin.latitude,
-            );
-            extendBounds(
-              bounds,
-              destination.lng ?? destination.longitude,
-              destination.lat ?? destination.latitude,
-            );
+            const oLng = getCoordLng(origin);
+            const oLat = getCoordLat(origin);
+            const dLng = getCoordLng(destination);
+            const dLat = getCoordLat(destination);
+            if (oLng !== undefined && oLat !== undefined) {
+              extendBounds(bounds, oLng, oLat);
+            }
+            if (dLng !== undefined && dLat !== undefined) {
+              extendBounds(bounds, dLng, dLat);
+            }
           }
 
           fitRouteBounds(map, bounds);

--- a/src/i18n/locale/en/translation.json
+++ b/src/i18n/locale/en/translation.json
@@ -819,5 +819,14 @@
   "alertMatchStation": "Station",
   "alertMatchLine": "Line",
   "alertMatchTrain": "Train",
-  "alertMatchSection": "Section"
+  "alertMatchSection": "Section",
+  "errorTitle": "Something went wrong",
+  "errorDescription": "The application encountered an unexpected issue. Please try reloading or return to the home page.",
+  "errorRetry": "Try again",
+  "errorGoHome": "Back to Home",
+  "errorDetails": "Error details",
+  "errorBoundaryFallbackTitle": "Failed to load section",
+  "errorBoundaryFallbackDesc": "This component encountered an error and cannot be displayed. Please try reloading.",
+  "errorGlobalTitle": "System Error",
+  "errorGlobalDescription": "A critical error occurred in the application. Please try reloading the page."
 }

--- a/src/i18n/locale/zh-TW/translation.json
+++ b/src/i18n/locale/zh-TW/translation.json
@@ -809,5 +809,14 @@
   "alertMatchStation": "車站",
   "alertMatchLine": "路線",
   "alertMatchTrain": "車次",
-  "alertMatchSection": "區間"
+  "alertMatchSection": "區間",
+  "errorTitle": "發生未預期錯誤",
+  "errorDescription": "應用程式遇到未預期的問題，請嘗試重新載入或返回首頁。",
+  "errorRetry": "重新嘗試",
+  "errorGoHome": "返回首頁",
+  "errorDetails": "詳細錯誤資訊",
+  "errorBoundaryFallbackTitle": "此區塊載入失敗",
+  "errorBoundaryFallbackDesc": "這個元件遇到問題無法正常顯示，請嘗試重新載入。",
+  "errorGlobalTitle": "系統發生重大錯誤",
+  "errorGlobalDescription": "應用程式核心元件發生錯誤，請嘗試重新載入頁面。"
 }

--- a/src/lib/ai/actionExecutor.ts
+++ b/src/lib/ai/actionExecutor.ts
@@ -1,10 +1,10 @@
-import useMapStore from "@/stores/useMapStore";
 import {
   extendBounds,
   fitRouteBounds,
   routeBoundsFromLegs,
 } from "@/lib/mapCamera";
-import type { UIAction, ActionResult } from "./uiAction";
+import useMapStore from "@/stores/useMapStore";
+import type { ActionResult, UIAction } from "./uiAction";
 
 export function executeAction(action: UIAction): ActionResult {
   const s = useMapStore.getState();
@@ -58,7 +58,7 @@ export function executeAction(action: UIAction): ActionResult {
     default:
       return {
         ok: false,
-        skipped: `unknown action: ${(action as any).type}`,
+        skipped: `unknown action: ${(action as { type?: string }).type ?? "unknown"}`,
       };
   }
 }

--- a/src/lib/ai/toolActionMapper.ts
+++ b/src/lib/ai/toolActionMapper.ts
@@ -23,30 +23,36 @@ export function mapToolToActions(
   }
 }
 
-function extractLatLng(
-  primary: unknown,
-  fallback: unknown,
-): LatLng | null {
+function extractLatLng(primary: unknown, fallback: unknown): LatLng | null {
   for (const src of [primary, fallback]) {
     if (!src || typeof src !== "object") continue;
     const o = src as Record<string, unknown>;
-    const lat = (o.lat ?? o.latitude) as number | undefined;
-    const lng = (o.lng ?? o.longitude) as number | undefined;
-    if (Number.isFinite(lat) && Number.isFinite(lng)) {
-      return { lat: lat!, lng: lng! };
+    const lat = o.lat ?? o.latitude;
+    const lng = o.lng ?? o.longitude;
+    if (
+      typeof lat === "number" &&
+      typeof lng === "number" &&
+      Number.isFinite(lat) &&
+      Number.isFinite(lng)
+    ) {
+      return { lat, lng };
     }
   }
   return null;
 }
 
 function mapRouteResult(result: unknown, args: unknown): UIAction[] {
-  const res = (result ?? {}) as Record<string, any>;
+  const res = (result ?? {}) as Record<string, unknown>;
   const parsed = (() => {
     if (typeof args === "string") {
-      try { return JSON.parse(args || "{}"); } catch { return {}; }
+      try {
+        return JSON.parse(args || "{}");
+      } catch {
+        return {};
+      }
     }
-    return args ?? {};
-  })() as Record<string, any>;
+    return (args ?? {}) as Record<string, unknown>;
+  })() as Record<string, unknown>;
 
   const origin = extractLatLng(res.origin, parsed.origin);
   const destination = extractLatLng(res.destination, parsed.destination);
@@ -55,8 +61,18 @@ function mapRouteResult(result: unknown, args: unknown): UIAction[] {
   const drawable =
     Array.isArray(aiRoutes) &&
     aiRoutes.length > 0 &&
-    aiRoutes.some((r: any) =>
-      r?.legs?.some((l: any) => l?.polyline?.length),
+    aiRoutes.some(
+      (r: unknown) =>
+        r &&
+        typeof r === "object" &&
+        Array.isArray((r as { legs?: unknown[] }).legs) &&
+        (r as { legs: unknown[] }).legs.some(
+          (l: unknown) =>
+            l &&
+            typeof l === "object" &&
+            Array.isArray((l as { polyline?: unknown[] }).polyline) &&
+            (l as { polyline: unknown[] }).polyline.length > 0,
+        ),
     );
 
   const actions: UIAction[] = [];

--- a/src/lib/ai/uiAction.ts
+++ b/src/lib/ai/uiAction.ts
@@ -1,6 +1,6 @@
-import type { LatLng, AiResultMarker } from "@/types";
-import type { AccessibleRoute } from "@/types/route";
 import type { SheetMode } from "@/stores/useMapStore";
+import type { AiResultMarker, LatLng } from "@/types";
+import type { AccessibleRoute } from "@/types/route";
 
 // ── Map ──
 

--- a/src/lib/api/ai.ts
+++ b/src/lib/api/ai.ts
@@ -35,7 +35,7 @@ export async function streamChatWithAgent(
     name: string,
     args: string,
     isDone: boolean,
-    result?: any,
+    result?: unknown,
   ) => void,
   signal?: AbortSignal,
 ): Promise<void> {
@@ -144,7 +144,9 @@ export async function streamChatWithAgent(
           } else if (delta?.content) {
             onChunk(delta.content);
           }
-        } catch {}
+        } catch (_err) {
+          // Ignore partial or non-JSON chunk in stream
+        }
       }
     }
   }

--- a/src/lib/toolResultCards.ts
+++ b/src/lib/toolResultCards.ts
@@ -515,14 +515,14 @@ export function getAggregatedToolResults(
     | Array<{ name: string; result?: unknown; status?: string }>
     | undefined,
 ): ToolResultGroup[] {
-  if (!activities || !activities.length) return [];
+  if (!activities?.length) return [];
 
   const groups: ToolResultGroup[] = [];
 
   for (const act of activities) {
     if (act.status === "running") continue;
     const group = getToolResultGroup(act.name, act.result);
-    if (!group || !group.items.length) continue;
+    if (!group?.items.length) continue;
 
     const existingIndex = groups.findIndex(
       (g) => g.icon === group.icon && g.heading === group.heading,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,6 @@ import {
   type IBathroom,
   type Marker,
   type metroA11yData,
-  type NominatimPlace,
 } from "@/types";
 
 export function cn(...inputs: ClassValue[]) {

--- a/src/lib/voice/__tests__/audioCapture.test.ts
+++ b/src/lib/voice/__tests__/audioCapture.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createCapture, type CreateCaptureDeps } from "../audioCapture";
+import { type CreateCaptureDeps, createCapture } from "../audioCapture";
 
 interface FakeTrack {
   stop: ReturnType<typeof vi.fn>;

--- a/src/lib/voice/__tests__/audioPlayback.test.ts
+++ b/src/lib/voice/__tests__/audioPlayback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createPlayback, type CreatePlaybackDeps } from "../audioPlayback";
+import { type CreatePlaybackDeps, createPlayback } from "../audioPlayback";
 
 interface FakeAudioBuffer {
   duration: number;

--- a/src/stores/__tests__/useAuthStore.test.ts
+++ b/src/stores/__tests__/useAuthStore.test.ts
@@ -1,7 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "@/lib/api/ai";
 import { updateConfig } from "@/lib/api/user";
-import useAuthStore from "@/stores/useAuthStore";
+import { revokeSession } from "@/lib/authTransport";
 import { ColorEnum, FontSizeEnum, LanguageEnum } from "@/lib/config";
+import useAuthStore from "@/stores/useAuthStore";
+import type { ChatBubble } from "@/stores/useChatStore";
+import useChatStore from "@/stores/useChatStore";
 import type { UserDTO } from "@/types/user";
 
 vi.mock("@/lib/api/user", () => ({
@@ -12,7 +16,13 @@ vi.mock("@/lib/api/user", () => ({
   }),
 }));
 
+vi.mock("@/lib/authTransport", () => ({
+  revokeSession: vi.fn().mockResolvedValue(undefined),
+  requestRefresh: vi.fn().mockResolvedValue(null),
+}));
+
 const mockUpdateConfig = vi.mocked(updateConfig);
+const mockRevokeSession = vi.mocked(revokeSession);
 
 const USER: UserDTO = {
   _id: "user-1",
@@ -29,6 +39,8 @@ describe("useAuthStore.updateUserConfig", () => {
     useAuthStore.setState({
       user: null,
       session: null,
+      authDialogRequested: false,
+      settingsDialogRequested: null,
       userConfig: {
         language: LanguageEnum.Chinese,
         darkMode: "system",
@@ -79,5 +91,198 @@ describe("useAuthStore.updateUserConfig", () => {
     expect(mockUpdateConfig).toHaveBeenCalledTimes(1);
     expect(mockUpdateConfig.mock.calls[0][0]).toEqual({ memoryEnabled: false });
     expect(useAuthStore.getState().userConfig.memoryEnabled).toBe(false);
+  });
+});
+
+describe("useAuthStore.logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({
+      user: null,
+      session: null,
+      authDialogRequested: false,
+      settingsDialogRequested: null,
+      userConfig: {
+        language: LanguageEnum.Chinese,
+        darkMode: "system",
+        themeColor: ColorEnum.Blue,
+        fontSize: FontSizeEnum.Medium,
+        notifications: false,
+        highContrast: false,
+        memoryEnabled: true,
+      },
+    });
+    useChatStore.setState({
+      hydrated: false,
+      messages: [],
+      input: "",
+      isLoading: false,
+      chatHistory: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("clears user and session synchronously", () => {
+    useAuthStore.setState({
+      user: USER,
+      session: { accessToken: "test-access-token" },
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().session).toBeNull();
+  });
+
+  it("clears AI chat conversation, chat history, and draft input in useChatStore for privacy protection", () => {
+    useAuthStore.setState({
+      user: USER,
+      session: { accessToken: "test-access-token" },
+    });
+
+    const activeMessages: ChatBubble[] = [
+      {
+        role: "user",
+        content: "我的住址在台北市中山區某路某號，我有輪椅代步需求",
+      },
+      {
+        role: "assistant",
+        content: "為您規劃捷運中山站無障礙路線與出入口資訊",
+        toolActivities: [
+          {
+            name: "getAccessibleRoute",
+            status: "done",
+            result: { routeId: "r-123" },
+          },
+        ],
+      },
+    ];
+    const activeHistory: ChatMessage[] = [
+      {
+        role: "user",
+        content: "我的住址在台北市中山區某路某號，我有輪椅代步需求",
+      },
+      {
+        role: "assistant",
+        content: "為您規劃捷運中山站無障礙路線與出入口資訊",
+      },
+    ];
+
+    useChatStore.setState({
+      messages: activeMessages,
+      chatHistory: activeHistory,
+      input: "請問附近有無障礙坡道嗎？",
+      isLoading: true,
+    });
+
+    expect(useChatStore.getState().messages).toHaveLength(2);
+    expect(useChatStore.getState().chatHistory).toHaveLength(2);
+    expect(useChatStore.getState().input).toBe("請問附近有無障礙坡道嗎？");
+
+    useAuthStore.getState().logout();
+
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().session).toBeNull();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().chatHistory).toEqual([]);
+    expect(useChatStore.getState().input).toBe("");
+  });
+
+  it("drops persisted sessionStorage snapshot when window/sessionStorage is available", () => {
+    const storeMap = new Map<string, string>();
+    const mockSessionStorage = {
+      getItem: vi.fn((key: string) => storeMap.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => storeMap.set(key, value)),
+      removeItem: vi.fn((key: string) => storeMap.delete(key)),
+      clear: vi.fn(() => storeMap.clear()),
+      length: 0,
+      key: vi.fn(),
+    };
+
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("sessionStorage", mockSessionStorage);
+
+    mockSessionStorage.setItem(
+      "aiChatConversation",
+      JSON.stringify({
+        messages: [{ role: "user", content: "機密隱私資訊" }],
+        chatHistory: [{ role: "user", content: "機密隱私資訊" }],
+      }),
+    );
+
+    useAuthStore.setState({
+      user: USER,
+      session: { accessToken: "test-token" },
+    });
+    useChatStore.setState({
+      messages: [{ role: "user", content: "機密隱私資訊" }],
+      chatHistory: [{ role: "user", content: "機密隱私資訊" }],
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(mockSessionStorage.removeItem).toHaveBeenCalledWith(
+      "aiChatConversation",
+    );
+    expect(mockSessionStorage.getItem("aiChatConversation")).toBeNull();
+  });
+
+  it("invokes revokeSession with the captured access token when logged in", () => {
+    useAuthStore.setState({
+      user: USER,
+      session: { accessToken: "token-to-revoke-123" },
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(mockRevokeSession).toHaveBeenCalledTimes(1);
+    expect(mockRevokeSession).toHaveBeenCalledWith("token-to-revoke-123");
+  });
+
+  it("does not call revokeSession when logging out without an active session", () => {
+    useAuthStore.setState({
+      user: null,
+      session: null,
+    });
+
+    useAuthStore.getState().logout();
+
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+  });
+
+  it("handles revokeSession failure gracefully without throwing or leaving dirty state", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    mockRevokeSession.mockRejectedValueOnce(
+      new Error("Network failure during token revocation"),
+    );
+
+    useAuthStore.setState({
+      user: USER,
+      session: { accessToken: "error-token" },
+    });
+    useChatStore.setState({
+      messages: [{ role: "user", content: "未清空的訊息" }],
+      chatHistory: [{ role: "user", content: "未清空的訊息" }],
+      input: "未發送的草稿",
+    });
+
+    expect(() => useAuthStore.getState().logout()).not.toThrow();
+
+    // Allow promise rejection handler in catch block to execute
+    await Promise.resolve();
+
+    expect(useAuthStore.getState().user).toBeNull();
+    expect(useAuthStore.getState().session).toBeNull();
+    expect(useChatStore.getState().messages).toEqual([]);
+    expect(useChatStore.getState().chatHistory).toEqual([]);
+    expect(useChatStore.getState().input).toBe("");
+    expect(consoleErrorSpy).toHaveBeenCalled();
   });
 });

--- a/src/stores/useMapStore.ts
+++ b/src/stores/useMapStore.ts
@@ -324,7 +324,7 @@ const useMapStore = create<MapStore>((set, get) => ({
       searchTerm.kind === "place"
         ? searchTerm.place.name || searchTerm.place.fullAddress || ""
         : searchTerm.address;
-    if (!name || !name.trim()) return;
+    if (!name?.trim()) return;
     const { searchHistory } = get();
     const deduped = searchHistory.filter((item) => {
       const itemName =
@@ -376,7 +376,7 @@ const useMapStore = create<MapStore>((set, get) => ({
       place.kind === "place"
         ? place.place.name || place.place.fullAddress || ""
         : place.address;
-    if (!name || !name.trim()) return;
+    if (!name?.trim()) return;
     const { savedPlaces, savedPlaceKeys } = get();
     const key = placeKey(place);
     if (savedPlaceKeys.has(key)) return;
@@ -531,7 +531,7 @@ const useMapStore = create<MapStore>((set, get) => ({
     set({ pendingNavExit: null });
   },
   setIsNavigating: (v) => {
-    const { map, userLocation: loc } = get();
+    const { map } = get();
     if (v) {
       set({ isNavigating: true, sheetMode: "navigation", is3D: true });
     } else {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,8 +12,8 @@ export type {
 } from "./place";
 
 export type {
-  MatchKind,
   MatchedAlert,
+  MatchKind,
   MetroAlert,
   TransitAlert,
 } from "./transit-alert";

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,11 +1,11 @@
 import type {
-  MatchKind,
   MatchedAlert,
+  MatchKind,
   MetroAlert,
   TransitAlert,
 } from "./transit-alert";
 
-export type { MatchKind, MatchedAlert, MetroAlert, TransitAlert };
+export type { MatchedAlert, MatchKind, MetroAlert, TransitAlert };
 
 // Types aligned with backend OpenAPI spec (POST /a11y/accessible-route)
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/__tests__/**/*.test.ts"],
+    include: [
+      "src/**/__tests__/**/*.test.ts",
+      "src/**/__tests__/**/*.test.tsx",
+    ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    env: {
+      TZ: "Asia/Taipei",
+    },
     include: [
       "src/**/__tests__/**/*.test.ts",
       "src/**/__tests__/**/*.test.tsx",


### PR DESCRIPTION
## 概要

本 PR 依據產品級工程稽核報告（優先級項目 1 至 6），完成全套關鍵修復與工程優化：

---

### 1. Phase 1：建立 Error Boundary 與 Next.js 錯誤頁面 (P1-1)
- **實作通用 React Class Component `ErrorBoundary`**：支援自訂 `fallback` 或預設無障礙錯誤卡片，支援重試回呼（`onReset`）。
- **Next.js 路由層級 `src/app/[lng]/error.tsx`**：提供全頁面崩潰時的無障礙錯誤降級介面，具備重試（`reset()`）與返回首頁按鈕。
- **全域 `src/app/global-error.tsx`**：根版面錯誤防護。
- **UI/UX 設計規範（`ui-ux-pro-max`）**：符合 WCAG 2.1 AA 無障礙標準，設定 `role="alert"`、44px 最小觸控熱區、全主題相容（Dark/Light/High-Contrast）與雙語系（zh-TW/en）。
- **單元測試**：新增 `ErrorBoundary.test.tsx` 與 `ErrorPages.test.tsx`。

---

### 2. Phase 2：建立 CI 護欄與修復 61 個 Biome Lint 錯誤 (P1-2)
- **新增 GitHub Actions CI (`.github/workflows/ci.yml`)`**：在 PR 與 push 時自動執行 `npm run lint`、`npx tsc --noEmit`、`npm test`。
- **清除全專案 61 個 Biome Lint Errors 與 76 個 Warnings**：
  - 修正 `globals.css` 中 `@layer base *` 的 CSS Specificity 順序與 `!important` 規則。
  - 修正 `A11yFacilityPin.tsx` 靜態 div 互動事件，提升鍵盤與螢幕閱讀器可及性。
  - 修正 `BusPanel.tsx`、`HazardReportPanel.tsx`、`HomeContent.tsx` 等面板中的 ARIA role 與 array index key 警告。
  - 自動整理各模組 Import 順序。
- **結果**：`npm run lint` (`biome check`) 達成 **0 errors, 0 warnings across 230 files**。

---

### 3. Phase 3：補齊登出對話隱私清理測試 (P1-3)
- **在 `useAuthStore.test.ts` 補齊 `logout()` 完整測試**：
  - 驗證登出時同步清空 `user` 與 `session`。
  - 驗證 `useChatStore` 的對話訊息、輸入草稿、工具狀態與 `sessionStorage` 歷程確實被徹底清除，防範共用裝置上的隱私外洩。
  - 驗證 Token 撤銷請求 (`revokeSession`) 正常發送與錯誤容錯。

---

### 4. Phase 4：優化 GPS 錯誤處理防 Toast 轟炸 (P1-4)
- **建立狀態轉移型定位錯誤處理器 (`src/lib/map/gpsErrorHandler.ts`)**：
  - 在 `ClientMap.tsx` 的 `watchPosition` 錯誤回呼中加入狀態追蹤，僅在**定位狀態首次進入錯誤狀態時提示一次**，徹底解決無訊號/地下道時每秒狂發 Toast 覆蓋畫面的問題。
  - 當定位恢復正常時自動重置錯誤狀態，支援自動恢復。
- **單元測試**：新增 `src/lib/map/__tests__/gpsErrorHandler.test.ts` 驗證狀態防抖與單次提示邏輯。

---

### 5. Phase 5：收斂 Nominatim 呼叫與修正 API 錯誤防護 (P2-1, P2-4, P2-5)
- **收斂 Nominatim 反向地理編碼 API (P2-1)**：
  - 在 `src/lib/api/placeSearch.ts` 建立集中式 `reverseGeocode()`，內建自訂 User-Agent、記憶體快取與統一錯誤解析。
  - 將 `ClientMap.tsx`、`SosDialog.tsx`、`HazardReportPanel.tsx`、`MapControlsWrapper.tsx` 共 5 處寫死之 URL 呼叫全數收斂。
- **修復 `createHazardReport` 錯誤防護 (P2-4)**：
  - `src/lib/api/a11y.ts` 封裝健全的 HTTP 狀態碼與 `ApiError` 處理，防止 502/504 導致未捕獲的 SyntaxError。
- **補齊圖片上傳客戶端檢查 (P2-5)**：
  - `HazardReportPanel.tsx` 加上 5MB 檔案大小上限與 MIME 類型檢查，防止超大圖檔造成行動端記憶體崩潰。
- **單元測試**：新增 `placeSearch.test.ts`、`a11y.test.ts` 與 `HazardReportPanel.test.ts`。

---

### 6. Phase 6：實施 Code Splitting 降低首頁體積 (P2-3)
- **動態按需載入（`next/dynamic`）**：
  - 將 `BottomSheet` 次級面板（`EnvironmentPanel`, `WelfarePanel`, `HazardReportPanel`, `ParkingPanel`, `StationDetailContent`, `BusPanel`, `RouteExplanationPanel`, `SavedPlacesPanel`）與重型元件（`AIChatBot`, `VoiceSessionHost`, `SosDialog`, `OnboardingFlow`）改為動態載入。
  - 依據 `ui-ux-pro-max` 規範打造無障礙骨架屏 (`PanelSkeletons.tsx`)，確保載入過程無版面跳動 (Zero CLS)。
- **體積優化結果**：首頁 `/[lng]` First Load JS 由 **815 kB 顯著降至 698 kB**。

---

### 驗證結果
- [x] `npm run lint` ➜ 0 errors, 0 warnings across 230 files
- [x] `npx tsc --noEmit` ➜ 0 errors
- [x] `npm test` ➜ 29 test suites passed, 257 tests passed
- [x] `npm run check:cycles` ➜ 0 circular dependencies
- [x] `npm run build` ➜ Next.js 15 Turbopack production build succeeded (698 kB First Load JS)
- [x] `GitHub Actions CI` ➜ Passed