### PR TITLE
feat: implement product-grade audit phase 4-6 fixes (GPS throttling, API refactor, dynamic code splitting)

### DIFF
--- a/docs/plan-phase-4-5-6.md
+++ b/docs/plan-phase-4-5-6.md
@@ -1,0 +1,60 @@
+# 產品級工程修復實作計劃（Phase 4, 5, 6）
+
+本計劃對應稽核報告 `docs/audit/2026-08-18-product-grade-audit.md` 中的建議處理順序 4, 5, 6 項。
+
+---
+
+## 專案規格與約束
+1. **UI/UX 設計規範**：嚴格遵循 `ui-ux-pro-max` 技能標準（WCAG 2.1 AA、最小 44px 觸控熱區、骨架屏防止 Layout Shift、防連點、錯誤狀態單次提示）。
+2. **Commit 策略**：每個 Phase 獨立進行 Conventional Commit。
+3. **隔離規範**：不 commit `docs/audit/2026-08-18-product-grade-audit.md`。
+
+---
+
+## Phase 4：優化 GPS 錯誤處理防 Toast 轟炸（P1-4）
+### 目標
+解決 `navigator.geolocation.watchPosition` 在無訊號、地下區域或權限拒絕時每秒連續發送錯誤 Toast 的問題。
+
+### 實作細節
+1. **`src/components/ClientMap.tsx`**：
+   - 建立狀態轉移型錯誤追蹤（如 `lastLocationErrorRef` 或 `isLocationErrorActive`），確保在連續收到定位錯誤時，僅在**狀態首次進入錯誤**時提示一次。
+   - 當定位恢復正常時重置錯誤標記。
+2. **測試防護**：
+   - 新增/更新測試驗證連續定位失敗時錯誤處理行為。
+
+---
+
+## Phase 5：收斂 Nominatim 呼叫與修正 API 錯誤防護（P2-1, P2-4, P2-5）
+### 目標
+統一反向地理編碼 API、修復回報端點錯誤防護、補齊圖片上傳體積與格式檢查。
+
+### 實作細節
+1. **收斂 Nominatim API（P2-1）**：
+   - 在 `src/lib/api/placeSearch.ts` 建立統一封裝 `reverseGeocode(lat, lng, lang)`：
+     - 包含快取、自訂 User-Agent、結構化錯誤回傳與 OSM 格式轉換。
+   - 將 5 個元件的直接 `fetch("https://nominatim...")` 替換為統一呼叫：
+     1. `src/components/ClientMap.tsx:297`
+     2. `src/components/ClientMap.tsx:389`
+     3. `src/components/Sos/SosDialog.tsx:358`
+     4. `src/components/BottomSheet/HazardReportPanel.tsx:103`
+     5. `src/components/Wrapper/MapControlsWrapper.tsx:203`
+2. **修復 `createHazardReport` 錯誤防護（P2-4）**：
+   - 在 `src/lib/api/a11y.ts` 中以 `fetchRequest` 或健全的 HTTP 狀態碼檢查封裝 `createHazardReport`，確保遇到 502/504 等非 JSON 錯誤時優雅降級為 `ApiError`。
+3. **圖片上傳客戶端驗證（P2-5）**：
+   - 在 `HazardReportPanel.tsx` 加上檔案大小上限（5MB）與 MIME 類型檢查（`image/jpeg`, `image/png`, `image/webp` 等），並在超限時給予友善提示。
+4. **單元測試**：
+   - 補齊反向地理編碼與檔案驗證的單元測試。
+
+---
+
+## Phase 6：實施 Code Splitting 降低首頁體積（P2-3）
+### 目標
+透過動態延遲載入（`next/dynamic`），將非首屏核心的重型模組按需載入，降低首次載入 JS 體積。
+
+### 實作細節
+1. **`src/components/BottomSheet/BottomSheet.tsx`**：
+   - 將次級面板（`EnvironmentPanel`, `WelfarePanel`, `HazardReportPanel`, `ParkingPanel`, `StationDetailContent`, `BusPanel`, `RouteExplanationPanel`, `SavedPlacesPanel` 等）改為 `next/dynamic` 載入，並搭配 `ui-ux-pro-max` 規格的平滑 Loading Fallback。
+2. **`src/components/ClientMap.tsx`**：
+   - 將 `AIChatBot`、`VoiceSessionHost`、`SosDialog` 改為動態載入。
+3. **驗證**：
+   - 執行 `npm run build` 確認首頁 Bundle 縮減，且所有功能運作正常。

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -17,12 +17,11 @@ import {
   X,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
-import AIChatBot from "@/components/AIChatBot";
-import ExitNavDialog from "@/components/Navigation/ExitNavDialog";
 import AccountLogin from "@/components/shared/AccountLogin";
 import useIsDesktop from "@/hook/useIsDesktop";
 import { useAppTranslation } from "@/i18n/client";
@@ -31,19 +30,79 @@ import type { RailPanel } from "@/stores/useMapStore";
 import useMapStore from "@/stores/useMapStore";
 import useNavStore from "@/stores/useNavStore";
 import useOnboardingStore from "@/stores/useOnboardingStore";
-import A11yPanel from "./A11yPanel";
-import BusPanel from "./BusPanel";
-import EnvironmentPanel from "./EnvironmentPanel";
-import HazardReportPanel from "./HazardReportPanel";
 import HomeContent from "./HomeContent";
-import NavigationContent from "./NavigationContent";
-import ParkingPanel from "./ParkingPanel";
-import PlaceContent from "./PlaceContent";
-import RouteContent from "./RouteContent";
-import RoutePlanContent from "./RoutePlanContent";
-import SavedPlacesPanel from "./SavedPlacesPanel";
-import StationDetailContent from "./StationDetailContent";
-import WelfarePanel from "./WelfarePanel";
+import {
+  A11yPanelSkeleton,
+  BusPanelSkeleton,
+  ChatSkeleton,
+  EnvironmentSkeleton,
+  HazardReportSkeleton,
+  NavigationSkeleton,
+  ParkingPanelSkeleton,
+  PlaceSkeleton,
+  RouteContentSkeleton,
+  RoutePlanSkeleton,
+  SavedPlacesSkeleton,
+  StationDetailSkeleton,
+  WelfareSkeleton,
+} from "./PanelSkeletons";
+
+const AIChatBot = dynamic(() => import("@/components/AIChatBot"), {
+  loading: () => <ChatSkeleton />,
+  ssr: false,
+});
+const ExitNavDialog = dynamic(
+  () => import("@/components/Navigation/ExitNavDialog"),
+  { ssr: false },
+);
+const A11yPanel = dynamic(() => import("./A11yPanel"), {
+  loading: () => <A11yPanelSkeleton />,
+  ssr: false,
+});
+const BusPanel = dynamic(() => import("./BusPanel"), {
+  loading: () => <BusPanelSkeleton />,
+  ssr: false,
+});
+const EnvironmentPanel = dynamic(() => import("./EnvironmentPanel"), {
+  loading: () => <EnvironmentSkeleton />,
+  ssr: false,
+});
+const HazardReportPanel = dynamic(() => import("./HazardReportPanel"), {
+  loading: () => <HazardReportSkeleton />,
+  ssr: false,
+});
+const ParkingPanel = dynamic(() => import("./ParkingPanel"), {
+  loading: () => <ParkingPanelSkeleton />,
+  ssr: false,
+});
+const SavedPlacesPanel = dynamic(() => import("./SavedPlacesPanel"), {
+  loading: () => <SavedPlacesSkeleton />,
+  ssr: false,
+});
+const WelfarePanel = dynamic(() => import("./WelfarePanel"), {
+  loading: () => <WelfareSkeleton />,
+  ssr: false,
+});
+const PlaceContent = dynamic(() => import("./PlaceContent"), {
+  loading: () => <PlaceSkeleton />,
+  ssr: false,
+});
+const RoutePlanContent = dynamic(() => import("./RoutePlanContent"), {
+  loading: () => <RoutePlanSkeleton />,
+  ssr: false,
+});
+const RouteContent = dynamic(() => import("./RouteContent"), {
+  loading: () => <RouteContentSkeleton />,
+  ssr: false,
+});
+const NavigationContent = dynamic(() => import("./NavigationContent"), {
+  loading: () => <NavigationSkeleton />,
+  ssr: false,
+});
+const StationDetailContent = dynamic(() => import("./StationDetailContent"), {
+  loading: () => <StationDetailSkeleton />,
+  ssr: false,
+});
 
 const SNAP_POINTS = {
   peek: 0.12,

--- a/src/components/BottomSheet/HazardReportPanel.tsx
+++ b/src/components/BottomSheet/HazardReportPanel.tsx
@@ -15,11 +15,39 @@ import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
 import { useAppTranslation } from "@/i18n/client";
 import { createHazardReport } from "@/lib/api/a11y";
+import { reverseGeocode } from "@/lib/api/placeSearch";
 import { haversineMeters } from "@/lib/geo";
-import { formatNominatimPlace } from "@/lib/utils";
 import useAuthStore from "@/stores/useAuthStore";
 import useMapStore from "@/stores/useMapStore";
 import { Button } from "../ui/button";
+
+export const MAX_REPORT_PHOTO_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+export const ALLOWED_REPORT_PHOTO_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/heic",
+  "image/heif",
+];
+
+export function validateHazardPhoto(file: {
+  size: number;
+  type: string;
+}):
+  | { valid: true }
+  | { valid: false; error: "IMAGE_TOO_LARGE" | "INVALID_IMAGE_TYPE" } {
+  if (
+    !ALLOWED_REPORT_PHOTO_TYPES.includes(file.type) &&
+    !file.type.startsWith("image/")
+  ) {
+    return { valid: false, error: "INVALID_IMAGE_TYPE" };
+  }
+  if (file.size > MAX_REPORT_PHOTO_SIZE_BYTES) {
+    return { valid: false, error: "IMAGE_TOO_LARGE" };
+  }
+  return { valid: true };
+}
 
 const HAZARD_TYPES = [
   { value: "obstacle" as const, Icon: TriangleAlert, color: "text-amber-500" },
@@ -100,13 +128,16 @@ export default function HazardReportPanel({
     const controller = new AbortController();
     const lang = i18n.language === "zh-TW" ? "zh-TW" : "en";
     setAddressFailed(false);
-    fetch(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${userLocation.lat}&lon=${userLocation.lng}&accept-language=${lang}&zoom=16&addressdetails=1`,
-      { signal: controller.signal },
+    reverseGeocode(
+      {
+        lat: userLocation.lat,
+        lng: userLocation.lng,
+        lang,
+        zoom: 16,
+      },
+      controller.signal,
     )
-      .then((res) => res.json())
-      .then((data) => {
-        const formatted = formatNominatimPlace(data, i18n.language);
+      .then((formatted) => {
         const a = formatted?.address;
         if (!a) {
           setAddressFailed(true);
@@ -118,11 +149,11 @@ export default function HazardReportPanel({
           a.road || a.neighbourhood || "",
         ]
           .filter(Boolean)
-          .join(i18n.language === "zh-TW" ? "" : ", ");
+          .join(lang === "zh-TW" ? "" : ", ");
         setAddress(composed || formatted.display_name || null);
       })
       .catch((err) => {
-        if ((err as Error).name === "AbortError") return;
+        if ((err as Error)?.name === "AbortError") return;
         setAddressFailed(true);
       });
     return () => controller.abort();
@@ -132,6 +163,18 @@ export default function HazardReportPanel({
   const handlePhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
+    const validation = validateHazardPhoto(file);
+    if (!validation.valid) {
+      if (validation.error === "INVALID_IMAGE_TYPE") {
+        toast.error(t("invalidImageType", "僅支援 JPG、PNG、WebP 等圖片格式"));
+      } else if (validation.error === "IMAGE_TOO_LARGE") {
+        toast.error(t("imageTooLarge", "圖片大小不能超過 5MB"));
+      }
+      if (fileRef.current) fileRef.current.value = "";
+      return;
+    }
+
     setPhoto(file);
     const reader = new FileReader();
     reader.onload = () => setPhotoPreview(reader.result as string);
@@ -275,7 +318,7 @@ export default function HazardReportPanel({
         <input
           ref={fileRef}
           type="file"
-          accept="image/*"
+          accept="image/jpeg,image/png,image/webp,image/gif,image/heic,image/heif,image/*"
           capture="environment"
           onChange={handlePhoto}
           className="hidden"
@@ -293,6 +336,7 @@ export default function HazardReportPanel({
               onClick={() => {
                 setPhoto(null);
                 setPhotoPreview(null);
+                if (fileRef.current) fileRef.current.value = "";
               }}
               className="absolute top-2 right-2 h-6 w-6 rounded-full bg-black/60 flex items-center justify-center"
             >

--- a/src/components/BottomSheet/PanelSkeletons.tsx
+++ b/src/components/BottomSheet/PanelSkeletons.tsx
@@ -1,0 +1,499 @@
+"use client";
+
+import { useAppTranslation } from "@/i18n/client";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "../ui/skeleton";
+
+interface SkeletonBaseProps {
+  className?: string;
+  label?: string;
+}
+
+const SKELETON_SLOTS_3 = ["s-1", "s-2", "s-3"] as const;
+const SKELETON_SLOTS_4 = ["s-1", "s-2", "s-3", "s-4"] as const;
+const SKELETON_SLOTS_5 = ["s-1", "s-2", "s-3", "s-4", "s-5"] as const;
+
+/**
+ * Base accessible wrapper for panel skeletons.
+ * Follows WCAG 2.1 AA / ui-ux-pro-max guidelines with status role, aria-busy, and sr-only announcement.
+ */
+export function PanelSkeletonWrapper({
+  className,
+  label,
+  children,
+}: SkeletonBaseProps & { children: React.ReactNode }) {
+  const { t } = useAppTranslation();
+  const accessibleLabel = label || t("loading", "載入中…");
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label={accessibleLabel}
+      className={cn("w-full space-y-4 py-1", className)}
+    >
+      <span className="sr-only">{accessibleLabel}</span>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Generic panel skeleton with header, chip filters, and card items.
+ */
+export function PanelSkeleton({ className, label }: SkeletonBaseProps) {
+  return (
+    <PanelSkeletonWrapper className={className} label={label}>
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-20 rounded-full" />
+      </div>
+      <div className="space-y-3 pt-2">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`panel-card-${id}`}
+            className="p-3.5 rounded-2xl bg-muted/30 border border-border/40 space-y-2.5"
+          >
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-36" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-3.5 w-48" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for A11y facilities panel.
+ */
+export function A11yPanelSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("accessibleTitle", "無障礙設施")}
+    >
+      {/* Category filter chips */}
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-24 rounded-full" />
+      </div>
+      {/* Facility items list */}
+      <div className="space-y-3 pt-1">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`a11y-item-${id}`}
+            className="p-3.5 rounded-2xl bg-muted/30 border border-border/40 space-y-2"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-5 rounded-md" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <Skeleton className="h-5 w-14 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-44" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Bus information panel.
+ */
+export function BusPanelSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("busInfo", "公車資訊")}
+    >
+      {/* Search bar placeholder */}
+      <Skeleton className="h-11 w-full rounded-2xl" />
+      {/* Segment tabs */}
+      <div className="flex gap-2">
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+      </div>
+      {/* Route list */}
+      <div className="space-y-2.5 pt-1">
+        {SKELETON_SLOTS_5.map((id) => (
+          <div
+            key={`bus-item-${id}`}
+            className="p-3 rounded-xl bg-muted/30 border border-border/40 flex items-center justify-between"
+          >
+            <div className="space-y-1.5 flex-1">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-3.5 w-36" />
+            </div>
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Parking information panel.
+ */
+export function ParkingPanelSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("parking", "停車資訊")}
+    >
+      <div className="flex gap-2">
+        <Skeleton className="h-9 w-24 rounded-full" />
+        <Skeleton className="h-9 w-28 rounded-full" />
+        <Skeleton className="h-9 w-28 rounded-full" />
+      </div>
+      <div className="space-y-3 pt-1">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`parking-item-${id}`}
+            className="p-3.5 rounded-2xl bg-muted/30 border border-border/40 space-y-2.5"
+          >
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+            </div>
+            <div className="flex gap-2">
+              <Skeleton className="h-4 w-20 rounded-md" />
+              <Skeleton className="h-4 w-24 rounded-md" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Environment panel.
+ */
+export function EnvironmentSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("environment", "環境資訊")}
+    >
+      {/* Target switch */}
+      <div className="flex gap-1 p-1 bg-muted/40 rounded-xl">
+        <Skeleton className="h-8 flex-1 rounded-lg" />
+        <Skeleton className="h-8 flex-1 rounded-lg" />
+      </div>
+      {/* Weather hero card */}
+      <div className="h-28 w-full rounded-2xl bg-muted/30 border border-border/40 p-4 flex flex-col justify-between">
+        <div className="flex justify-between items-start">
+          <div className="space-y-1.5">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+          </div>
+          <Skeleton className="h-10 w-10 rounded-full" />
+        </div>
+        <Skeleton className="h-4 w-40" />
+      </div>
+      {/* 2x2 Metrics Grid */}
+      <div className="grid grid-cols-2 gap-2.5">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`env-metric-${id}`}
+            className="h-20 rounded-2xl bg-muted/30 border border-border/40 p-3 space-y-2"
+          >
+            <Skeleton className="h-3.5 w-16" />
+            <Skeleton className="h-5 w-20" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Hazard report panel.
+ */
+export function HazardReportSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("reportHazard", "回報障礙")}
+    >
+      <Skeleton className="h-12 w-full rounded-2xl" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-24" />
+        <div className="flex gap-2">
+          <Skeleton className="h-9 w-24 rounded-full" />
+          <Skeleton className="h-9 w-24 rounded-full" />
+          <Skeleton className="h-9 w-24 rounded-full" />
+        </div>
+      </div>
+      {/* Photo upload placeholder */}
+      <div className="h-28 w-full rounded-2xl border-2 border-dashed border-muted/60 flex items-center justify-center">
+        <Skeleton className="h-8 w-32 rounded-lg" />
+      </div>
+      {/* Textarea placeholder */}
+      <Skeleton className="h-20 w-full rounded-2xl" />
+      {/* Submit button */}
+      <Skeleton className="h-11 w-full rounded-2xl" />
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Saved places panel.
+ */
+export function SavedPlacesSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("savedPlaces", "已存地點")}
+    >
+      <div className="flex gap-2 overflow-hidden">
+        <Skeleton className="h-8 w-16 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-20 rounded-full" />
+      </div>
+      <div className="space-y-2.5 pt-1">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`saved-item-${id}`}
+            className="p-3.5 rounded-2xl bg-muted/30 border border-border/40 flex items-center gap-3"
+          >
+            <Skeleton className="h-10 w-10 rounded-xl shrink-0" />
+            <div className="space-y-1.5 flex-1 min-w-0">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Welfare resources panel.
+ */
+export function WelfareSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("welfare", "福利資源")}
+    >
+      <Skeleton className="h-10 w-full rounded-2xl" />
+      <div className="flex gap-2">
+        <Skeleton className="h-8 w-20 rounded-full" />
+        <Skeleton className="h-8 w-24 rounded-full" />
+        <Skeleton className="h-8 w-24 rounded-full" />
+      </div>
+      <div className="space-y-3 pt-1">
+        {SKELETON_SLOTS_3.map((id) => (
+          <div
+            key={`welfare-item-${id}`}
+            className="p-3.5 rounded-2xl bg-muted/30 border border-border/40 space-y-2.5"
+          >
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-5 w-44" />
+              <Skeleton className="h-4 w-16 rounded-full" />
+            </div>
+            <Skeleton className="h-3.5 w-full" />
+            <Skeleton className="h-3 w-40" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Place detail content.
+ */
+export function PlaceSkeleton({ className }: SkeletonBaseProps) {
+  return (
+    <PanelSkeletonWrapper className={className}>
+      {/* Cover / image box */}
+      <Skeleton className="h-40 w-full rounded-2xl" />
+      {/* Title & subtitle */}
+      <div className="space-y-2 pt-1">
+        <Skeleton className="h-6 w-48" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </div>
+      {/* Action buttons grid (44px min height for touch target) */}
+      <div className="grid grid-cols-4 gap-2 pt-1">
+        {SKELETON_SLOTS_4.map((id) => (
+          <Skeleton key={`place-btn-${id}`} className="h-11 rounded-xl" />
+        ))}
+      </div>
+      {/* Place details list */}
+      <div className="space-y-2 pt-2">
+        <Skeleton className="h-10 w-full rounded-xl" />
+        <Skeleton className="h-10 w-full rounded-xl" />
+        <Skeleton className="h-10 w-full rounded-xl" />
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Route planning content.
+ */
+export function RoutePlanSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("planRoute", "規劃路線")}
+    >
+      {/* Origin/Destination inputs container */}
+      <div className="p-3 rounded-2xl bg-muted/30 border border-border/40 space-y-2.5">
+        <Skeleton className="h-10 w-full rounded-xl" />
+        <Skeleton className="h-10 w-full rounded-xl" />
+      </div>
+      {/* Mode selection tabs */}
+      <div className="flex gap-2">
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+      </div>
+      {/* Route option cards */}
+      <div className="space-y-3 pt-1">
+        <Skeleton className="h-24 w-full rounded-2xl" />
+        <Skeleton className="h-24 w-full rounded-2xl" />
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Route calculation summary & steps.
+ */
+export function RouteContentSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper className={className} label={t("route", "路線")}>
+      <Skeleton className="h-20 w-full rounded-2xl" />
+      <div className="space-y-3 pt-2">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div key={`route-step-${id}`} className="flex gap-3 items-start p-2">
+            <Skeleton className="h-6 w-6 rounded-full shrink-0 mt-0.5" />
+            <div className="space-y-1.5 flex-1">
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Navigation instructions content.
+ */
+export function NavigationSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("navInstructions", "導航指引")}
+    >
+      <Skeleton className="h-16 w-full rounded-2xl" />
+      <div className="space-y-3 pt-2">
+        {SKELETON_SLOTS_4.map((id) => (
+          <div
+            key={`nav-step-${id}`}
+            className="p-3 rounded-xl bg-muted/30 border border-border/40 flex items-center justify-between"
+          >
+            <div className="space-y-1.5 flex-1">
+              <Skeleton className="h-4 w-44" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+            <Skeleton className="h-5 w-12 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for Station details content.
+ */
+export function StationDetailSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={className}
+      label={t("stationDetail", "車站詳情")}
+    >
+      <div className="space-y-2">
+        <Skeleton className="h-6 w-40" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+      <div className="flex gap-2">
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+        <Skeleton className="h-9 flex-1 rounded-xl" />
+      </div>
+      <div className="space-y-2.5 pt-1">
+        {SKELETON_SLOTS_4.map((id) => (
+          <Skeleton
+            key={`station-fac-${id}`}
+            className="h-14 w-full rounded-xl"
+          />
+        ))}
+      </div>
+    </PanelSkeletonWrapper>
+  );
+}
+
+/**
+ * Accessible skeleton for AI Chatbot assistant panel.
+ */
+export function ChatSkeleton({ className }: SkeletonBaseProps) {
+  const { t } = useAppTranslation();
+  return (
+    <PanelSkeletonWrapper
+      className={cn("h-full flex flex-col justify-between p-3", className)}
+      label={t("assist", "AI 助理")}
+    >
+      <div className="space-y-4 flex-1">
+        {/* Assistant greeting bubble */}
+        <div className="flex items-start gap-2.5 max-w-[85%]">
+          <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+          <Skeleton className="h-16 w-56 rounded-2xl" />
+        </div>
+        {/* User response bubble */}
+        <div className="flex justify-end">
+          <Skeleton className="h-10 w-40 rounded-2xl" />
+        </div>
+        {/* Assistant reply bubble */}
+        <div className="flex items-start gap-2.5 max-w-[85%]">
+          <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+          <Skeleton className="h-20 w-64 rounded-2xl" />
+        </div>
+      </div>
+      {/* Chat input box */}
+      <Skeleton className="h-12 w-full rounded-2xl mt-4 shrink-0" />
+    </PanelSkeletonWrapper>
+  );
+}

--- a/src/components/BottomSheet/PlaceContent.tsx
+++ b/src/components/BottomSheet/PlaceContent.tsx
@@ -18,6 +18,7 @@ import {
   Navigation,
   Share2,
 } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useAppTranslation } from "@/i18n/client";
@@ -31,7 +32,23 @@ import { checklistPriorityOrder } from "@/types/a11yProfile";
 import type { OsmPlaceDetail } from "@/types/route";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import PlaceReviewSection from "./PlaceReviewSection";
+import { Skeleton } from "../ui/skeleton";
+
+const PlaceReviewSection = dynamic(() => import("./PlaceReviewSection"), {
+  loading: () => (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="space-y-3 pt-4 border-t border-border/40 animate-pulse"
+    >
+      <Skeleton className="h-6 w-28" />
+      <Skeleton className="h-20 w-full rounded-2xl" />
+      <Skeleton className="h-20 w-full rounded-2xl" />
+    </div>
+  ),
+  ssr: false,
+});
 
 function getOsmIdFromPlaceId(placeId: string): string | null {
   const match = /^osm:(node|way|relation):(\d+)$/.exec(placeId);

--- a/src/components/BottomSheet/RouteContent.tsx
+++ b/src/components/BottomSheet/RouteContent.tsx
@@ -7,6 +7,7 @@ import {
   Navigation,
   Sparkles,
 } from "lucide-react";
+import dynamic from "next/dynamic";
 import { useShallow } from "zustand/react/shallow";
 import { useAppTranslation } from "@/i18n/client";
 import useMapStore from "@/stores/useMapStore";
@@ -15,9 +16,24 @@ import LoadingDrawer from "../shared/LoadingDrawer";
 import { RouteCard } from "../shared/RouteCard";
 import { TransitAlertsBanner } from "../shared/TransitAlerts";
 import { Button } from "../ui/button";
-import EnvironmentPanel from "./EnvironmentPanel";
-import HazardReportPanel from "./HazardReportPanel";
-import RouteExplanationPanel from "./RouteExplanationPanel";
+import {
+  EnvironmentSkeleton,
+  HazardReportSkeleton,
+  PanelSkeleton,
+} from "./PanelSkeletons";
+
+const EnvironmentPanel = dynamic(() => import("./EnvironmentPanel"), {
+  loading: () => <EnvironmentSkeleton />,
+  ssr: false,
+});
+const HazardReportPanel = dynamic(() => import("./HazardReportPanel"), {
+  loading: () => <HazardReportSkeleton />,
+  ssr: false,
+});
+const RouteExplanationPanel = dynamic(() => import("./RouteExplanationPanel"), {
+  loading: () => <PanelSkeleton />,
+  ssr: false,
+});
 
 export default function RouteContent() {
   const { t } = useAppTranslation();

--- a/src/components/BottomSheet/__tests__/HazardReportPanel.test.ts
+++ b/src/components/BottomSheet/__tests__/HazardReportPanel.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALLOWED_REPORT_PHOTO_TYPES,
+  MAX_REPORT_PHOTO_SIZE_BYTES,
+  validateHazardPhoto,
+} from "@/components/BottomSheet/HazardReportPanel";
+
+describe("HazardReportPanel photo validation (P2-5)", () => {
+  it("defines 5MB size limit and allowed MIME types", () => {
+    expect(MAX_REPORT_PHOTO_SIZE_BYTES).toBe(5 * 1024 * 1024);
+    expect(ALLOWED_REPORT_PHOTO_TYPES).toContain("image/jpeg");
+    expect(ALLOWED_REPORT_PHOTO_TYPES).toContain("image/png");
+    expect(ALLOWED_REPORT_PHOTO_TYPES).toContain("image/webp");
+  });
+
+  it("accepts valid JPEG, PNG, and WebP images within 5MB", () => {
+    const jpeg = { size: 1024 * 1024, type: "image/jpeg" }; // 1MB
+    const png = { size: 3 * 1024 * 1024, type: "image/png" }; // 3MB
+    const webp = { size: 500 * 1024, type: "image/webp" }; // 500KB
+
+    expect(validateHazardPhoto(jpeg)).toEqual({ valid: true });
+    expect(validateHazardPhoto(png)).toEqual({ valid: true });
+    expect(validateHazardPhoto(webp)).toEqual({ valid: true });
+  });
+
+  it("rejects files exceeding 5MB with IMAGE_TOO_LARGE", () => {
+    const tooLarge = {
+      size: 5 * 1024 * 1024 + 1, // 5MB + 1 byte
+      type: "image/jpeg",
+    };
+
+    expect(validateHazardPhoto(tooLarge)).toEqual({
+      valid: false,
+      error: "IMAGE_TOO_LARGE",
+    });
+  });
+
+  it("rejects non-image files with INVALID_IMAGE_TYPE", () => {
+    const pdf = { size: 1024 * 1024, type: "application/pdf" };
+    const text = { size: 500, type: "text/plain" };
+    const exe = { size: 2048, type: "application/x-msdownload" };
+    const video = { size: 2 * 1024 * 1024, type: "video/mp4" };
+
+    expect(validateHazardPhoto(pdf)).toEqual({
+      valid: false,
+      error: "INVALID_IMAGE_TYPE",
+    });
+    expect(validateHazardPhoto(text)).toEqual({
+      valid: false,
+      error: "INVALID_IMAGE_TYPE",
+    });
+    expect(validateHazardPhoto(exe)).toEqual({
+      valid: false,
+      error: "INVALID_IMAGE_TYPE",
+    });
+    expect(validateHazardPhoto(video)).toEqual({
+      valid: false,
+      error: "INVALID_IMAGE_TYPE",
+    });
+  });
+
+  it("accepts other image MIME subtypes", () => {
+    const bmp = { size: 500 * 1024, type: "image/bmp" };
+    expect(validateHazardPhoto(bmp)).toEqual({ valid: true });
+  });
+});

--- a/src/components/BottomSheet/__tests__/PanelSkeletons.test.tsx
+++ b/src/components/BottomSheet/__tests__/PanelSkeletons.test.tsx
@@ -1,0 +1,131 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  A11yPanelSkeleton,
+  BusPanelSkeleton,
+  ChatSkeleton,
+  EnvironmentSkeleton,
+  HazardReportSkeleton,
+  NavigationSkeleton,
+  PanelSkeleton,
+  ParkingPanelSkeleton,
+  PlaceSkeleton,
+  RouteContentSkeleton,
+  RoutePlanSkeleton,
+  SavedPlacesSkeleton,
+  StationDetailSkeleton,
+  WelfareSkeleton,
+} from "../PanelSkeletons";
+
+// Mock i18n
+vi.mock("@/i18n/client", () => ({
+  useAppTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+    i18n: { language: "zh-TW" },
+  }),
+}));
+
+describe("PanelSkeletons Accessibility & Structure", () => {
+  it("PanelSkeleton renders with role=status, aria-busy=true and pulse animation", () => {
+    const html = renderToStaticMarkup(<PanelSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain("animate-pulse");
+    expect(html).toContain("sr-only");
+  });
+
+  it("A11yPanelSkeleton renders accessibility label and skeleton chips", () => {
+    const html = renderToStaticMarkup(<A11yPanelSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("無障礙設施");
+    expect(html).toContain("animate-pulse");
+  });
+
+  it("BusPanelSkeleton renders bus info label and search placeholder", () => {
+    const html = renderToStaticMarkup(<BusPanelSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("公車資訊");
+  });
+
+  it("ParkingPanelSkeleton renders parking label", () => {
+    const html = renderToStaticMarkup(<ParkingPanelSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("停車資訊");
+  });
+
+  it("EnvironmentSkeleton renders environment label and grid", () => {
+    const html = renderToStaticMarkup(<EnvironmentSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("環境資訊");
+    expect(html).toContain("grid-cols-2");
+  });
+
+  it("HazardReportSkeleton renders hazard report label and photo upload wireframe", () => {
+    const html = renderToStaticMarkup(<HazardReportSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("回報障礙");
+  });
+
+  it("SavedPlacesSkeleton renders saved places label", () => {
+    const html = renderToStaticMarkup(<SavedPlacesSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("已存地點");
+  });
+
+  it("WelfareSkeleton renders welfare label", () => {
+    const html = renderToStaticMarkup(<WelfareSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("福利資源");
+  });
+
+  it("PlaceSkeleton renders place detail wireframe with 44px min touch buttons", () => {
+    const html = renderToStaticMarkup(<PlaceSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("grid-cols-4");
+    expect(html).toContain("h-11");
+  });
+
+  it("RoutePlanSkeleton renders route planning inputs wireframe", () => {
+    const html = renderToStaticMarkup(<RoutePlanSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("規劃路線");
+  });
+
+  it("RouteContentSkeleton renders route calculation wireframe", () => {
+    const html = renderToStaticMarkup(<RouteContentSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("路線");
+  });
+
+  it("NavigationSkeleton renders navigation instructions wireframe", () => {
+    const html = renderToStaticMarkup(<NavigationSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("導航指引");
+  });
+
+  it("StationDetailSkeleton renders station detail wireframe", () => {
+    const html = renderToStaticMarkup(<StationDetailSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("車站詳情");
+  });
+
+  it("ChatSkeleton renders AI chatbot conversation wireframe", () => {
+    const html = renderToStaticMarkup(<ChatSkeleton />);
+    expect(html).toContain('role="status"');
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain("AI 助理");
+  });
+});

--- a/src/components/ClientMap.tsx
+++ b/src/components/ClientMap.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type maplibregl from "maplibre-gl";
+import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { MapLayerMouseEvent } from "react-map-gl/maplibre";
@@ -13,22 +14,25 @@ import MapWrapper from "@/components/Wrapper/MapWrapper";
 import RoutePreviewHydrator from "@/components/Wrapper/RoutePreviewHydrator";
 import RouteLine from "@/components/Wrapper/RouteWrapper";
 import { useAppTranslation } from "@/i18n/client";
-import { getPlaceDetails } from "@/lib/api/placeSearch";
+import { getPlaceDetails, reverseGeocode } from "@/lib/api/placeSearch";
 import { applyMapDimension, type MapTheme } from "@/lib/map/basemap3d";
+import { createGpsErrorTracker } from "@/lib/map/gpsErrorHandler";
 import { nominatimToPlaceResult } from "@/lib/place/adapters";
 import { toApiLang } from "@/lib/place/lang";
-import { formatNominatimPlace } from "@/lib/utils";
 import useMapStore from "@/stores/useMapStore";
 import useNavStore from "@/stores/useNavStore";
 import NavigationController from "./NavigationController";
 import SearchPin from "./shared/SearchPin";
-import VoiceSessionHost from "./Voice/VoiceSessionHost";
 import AIResultWrapper from "./Wrapper/AIResultWrapper";
 import HazardWrapper from "./Wrapper/HazardWrapper";
 import LiveBusWrapper from "./Wrapper/LiveBusWrapper";
 import MapControlsWrapper from "./Wrapper/MapControlsWrapper";
 import SosTrackerWrapper from "./Wrapper/SosTrackerWrapper";
 import TransitWrapper from "./Wrapper/TransitWrapper";
+
+const VoiceSessionHost = dynamic(() => import("./Voice/VoiceSessionHost"), {
+  ssr: false,
+});
 
 const MAP_STYLES = {
   light: "https://tiles.openfreemap.org/styles/liberty",
@@ -113,7 +117,7 @@ export default function ClientMap() {
     })),
   );
   const { resolvedTheme } = useTheme();
-  const { i18n } = useAppTranslation();
+  const { i18n, t } = useAppTranslation();
   const [mounted, setMounted] = useState(false);
 
   // Shared-location links (?loc=lat,lng) start the camera on the shared point.
@@ -132,7 +136,9 @@ export default function ClientMap() {
         const { lat, lng } = JSON.parse(cached);
         if (Number.isFinite(lat) && Number.isFinite(lng)) return { lat, lng };
       }
-    } catch {}
+    } catch (_err) {
+      // Ignore corrupted localStorage cache
+    }
     return null;
   });
 
@@ -151,6 +157,7 @@ export default function ClientMap() {
 
   const pointerDownTime = useRef(0);
   const pointerDownPos = useRef<[number, number]>([0, 0]);
+  const locationErrorTracker = useRef(createGpsErrorTracker());
 
   // The OpenFreeMap sprite lacks some POI icons (gate, bollard, …); register
   // a transparent 1×1 stand-in so MapLibre stops warning on every tile
@@ -221,12 +228,19 @@ export default function ClientMap() {
       setUserLocation(loc);
       try {
         localStorage.setItem("lastUserLocation", JSON.stringify(loc));
-      } catch {}
-      const t = setInterval(() => setUserLocation(loc), 2000);
-      return () => clearInterval(t);
+      } catch (_err) {
+        // localStorage write failure is non-fatal.
+      }
+      const tId = setInterval(() => setUserLocation(loc), 2000);
+      return () => clearInterval(tId);
     }
 
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+
+    const tracker = locationErrorTracker.current;
+
     const onPos = (pos: GeolocationPosition) => {
+      tracker.recordSuccess();
       const loc = {
         lat: pos.coords.latitude,
         lng: pos.coords.longitude,
@@ -234,11 +248,19 @@ export default function ClientMap() {
       setUserLocation(loc);
       try {
         localStorage.setItem("lastUserLocation", JSON.stringify(loc));
-      } catch {}
+      } catch (_err) {
+        // localStorage write failure is non-fatal.
+      }
       const h = pos.coords.heading;
       useNavStore
         .getState()
         .setGpsHeading(typeof h === "number" && !Number.isNaN(h) ? h : null);
+    };
+
+    const onPosError = () => {
+      tracker.recordError(() => {
+        toast.error(t("noLocation", "無法取得目前位置"));
+      });
     };
 
     // Fast coarse fix so the map centers on the user immediately, then
@@ -249,15 +271,12 @@ export default function ClientMap() {
       timeout: 5_000,
     });
 
-    const watchId = navigator.geolocation.watchPosition(
-      onPos,
-      () => {
-        toast.error("無法取得目前位置");
-      },
-      { enableHighAccuracy: true, maximumAge: 1000 },
-    );
+    const watchId = navigator.geolocation.watchPosition(onPos, onPosError, {
+      enableHighAccuracy: true,
+      maximumAge: 1000,
+    });
     return () => navigator.geolocation.clearWatch(watchId);
-  }, [setUserLocation]);
+  }, [setUserLocation, t]);
 
   // Cold-load with no share link: recenter the camera on the user's first GPS
   // fix instead of leaving it on the hardcoded Taipei fallback. Fires once so
@@ -294,12 +313,8 @@ export default function ClientMap() {
     const position = { lat, lng };
     const lang = i18n.language === "zh-TW" ? "zh-TW" : "en";
     setSheetMode("place");
-    fetch(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&accept-language=${lang}&zoom=18&addressdetails=1`,
-    )
-      .then((res) => res.json())
-      .then((data) => {
-        const formatted = formatNominatimPlace(data, i18n.language);
+    reverseGeocode({ lat, lng, lang, zoom: 18 })
+      .then((formatted) => {
         if (!formatted) throw new Error("Reverse geocoding failed");
 
         const place = nominatimToPlaceResult(formatted);
@@ -386,11 +401,7 @@ export default function ClientMap() {
       setSheetMode("place");
 
       try {
-        const res = await fetch(
-          `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&accept-language=${lang}&zoom=18&addressdetails=1`,
-        );
-        const data = await res.json();
-        const formatted = formatNominatimPlace(data, i18n.language);
+        const formatted = await reverseGeocode({ lat, lng, lang, zoom: 18 });
 
         if (formatted) {
           const place = nominatimToPlaceResult(formatted);
@@ -408,7 +419,7 @@ export default function ClientMap() {
         } else {
           setInfoShow({ isOpen: false, kind: null });
         }
-      } catch {
+      } catch (_err) {
         setInfoShow({ isOpen: false, kind: null });
       }
     },

--- a/src/components/Onboarding/OnboardingHost.tsx
+++ b/src/components/Onboarding/OnboardingHost.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import useOnboardingStore from "@/stores/useOnboardingStore";
-import OnboardingFlow from "./OnboardingFlow";
+
+const OnboardingFlow = dynamic(() => import("./OnboardingFlow"), {
+  ssr: false,
+});
 
 /**
  * URL parameters that mean the user arrived with a specific intent rather than

--- a/src/components/Sos/SosDialog.tsx
+++ b/src/components/Sos/SosDialog.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/dialog";
 import { useSosLifecycle } from "@/hook/useSosLifecycle";
 import { useAppTranslation } from "@/i18n/client";
+import { reverseGeocode } from "@/lib/api/placeSearch";
 import {
   createSosSession,
   getEmergencyContacts,
@@ -35,7 +36,6 @@ import {
 } from "@/lib/api/sos";
 import { ApiError } from "@/lib/fetch";
 import { clearActiveSos, loadActiveSos, saveActiveSos } from "@/lib/sosSession";
-import { formatNominatimPlace } from "@/lib/utils";
 import useAuthStore from "@/stores/useAuthStore";
 import useMapStore from "@/stores/useMapStore";
 import type {
@@ -355,13 +355,16 @@ export default function SosDialog({
     if (step !== "active" || !userLocation) return;
     const controller = new AbortController();
     const lang = i18n.language === "zh-TW" ? "zh-TW" : "en";
-    fetch(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${userLocation.lat}&lon=${userLocation.lng}&accept-language=${lang}&zoom=16&addressdetails=1`,
-      { signal: controller.signal },
+    reverseGeocode(
+      {
+        lat: userLocation.lat,
+        lng: userLocation.lng,
+        lang,
+        zoom: 16,
+      },
+      controller.signal,
     )
-      .then((res) => res.json())
-      .then((data) => {
-        const formatted = formatNominatimPlace(data, i18n.language);
+      .then((formatted) => {
         setAddress(formatted?.display_name ?? null);
       })
       .catch(() => {});

--- a/src/components/Wrapper/MapControlsWrapper.tsx
+++ b/src/components/Wrapper/MapControlsWrapper.tsx
@@ -19,10 +19,10 @@ import {
   Wind,
 } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
+import dynamic from "next/dynamic";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
-import SosDialog from "@/components/Sos/SosDialog";
 import ShareTargets from "@/components/shared/ShareTargets";
 import { Button } from "@/components/ui/button";
 import {
@@ -35,10 +35,15 @@ import useIsDesktop from "@/hook/useIsDesktop";
 import usePin from "@/hook/usePin";
 import { useAppTranslation } from "@/i18n/client";
 import { getEnvironmentInfo } from "@/lib/api/a11y";
-import { cn, formatNominatimPlace } from "@/lib/utils";
+import { reverseGeocode } from "@/lib/api/placeSearch";
+import { cn } from "@/lib/utils";
 import useMapStore from "@/stores/useMapStore";
 import useNavStore from "@/stores/useNavStore";
 import type { AirQualityLevel, EnvironmentData } from "@/types/route";
+
+const SosDialog = dynamic(() => import("@/components/Sos/SosDialog"), {
+  ssr: false,
+});
 
 // SOS is now a single tap — no hold required for accessibility
 
@@ -200,13 +205,16 @@ export default function MapControlsWrapper() {
     if (!shareOpen || !userLocation) return;
     const controller = new AbortController();
     const lang = i18n.language === "zh-TW" ? "zh-TW" : "en";
-    fetch(
-      `https://nominatim.openstreetmap.org/reverse?format=json&lat=${userLocation.lat}&lon=${userLocation.lng}&accept-language=${lang}&zoom=16&addressdetails=1`,
-      { signal: controller.signal },
+    reverseGeocode(
+      {
+        lat: userLocation.lat,
+        lng: userLocation.lng,
+        lang,
+        zoom: 16,
+      },
+      controller.signal,
     )
-      .then((res) => res.json())
-      .then((data) => {
-        const formatted = formatNominatimPlace(data, i18n.language);
+      .then((formatted) => {
         const a = formatted?.address;
         if (!a) return;
         const composed = [

--- a/src/components/shared/AccountLogin.tsx
+++ b/src/components/shared/AccountLogin.tsx
@@ -22,19 +22,12 @@ import {
   SlidersHorizontal,
   Type,
 } from "lucide-react";
+import dynamic from "next/dynamic";
 import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
-import EmergencyContactsDialog from "@/components/Sos/EmergencyContactsDialog";
-import EmergencyContactsManager from "@/components/Sos/EmergencyContactsManager";
-import AccountSecurityPanel from "@/components/settings/AccountSecurityPanel";
-import AIMemoryPanel from "@/components/settings/AIMemoryPanel";
-import DataManagementPanel from "@/components/settings/DataManagementPanel";
-import AuthDialog from "@/components/shared/AuthDialog";
-import HelpDialog from "@/components/shared/HelpDialog";
-import LineBindDialog from "@/components/shared/LineBindDialog";
 import {
   Dialog,
   DialogContent,
@@ -67,6 +60,37 @@ import useQuickActionsStore from "@/stores/useQuickActionsStore";
 import { Button } from "../ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger } from "../ui/select";
 import { ThemeSwitcher } from "../ui/shadcn-io/theme-switcher";
+
+const EmergencyContactsDialog = dynamic(
+  () => import("@/components/Sos/EmergencyContactsDialog"),
+  { ssr: false },
+);
+const EmergencyContactsManager = dynamic(
+  () => import("@/components/Sos/EmergencyContactsManager"),
+  { ssr: false },
+);
+const AccountSecurityPanel = dynamic(
+  () => import("@/components/settings/AccountSecurityPanel"),
+  { ssr: false },
+);
+const AIMemoryPanel = dynamic(
+  () => import("@/components/settings/AIMemoryPanel"),
+  { ssr: false },
+);
+const DataManagementPanel = dynamic(
+  () => import("@/components/settings/DataManagementPanel"),
+  { ssr: false },
+);
+const AuthDialog = dynamic(() => import("@/components/shared/AuthDialog"), {
+  ssr: false,
+});
+const HelpDialog = dynamic(() => import("@/components/shared/HelpDialog"), {
+  ssr: false,
+});
+const LineBindDialog = dynamic(
+  () => import("@/components/shared/LineBindDialog"),
+  { ssr: false },
+);
 
 export default function AccountLogin({ active = true }: { active?: boolean }) {
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("general");

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted/60", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/i18n/locale/en/translation.json
+++ b/src/i18n/locale/en/translation.json
@@ -299,6 +299,8 @@
   "reportSuccess": "Report submitted! Thank you for your contribution",
   "reportFailed": "Report failed, please try again later",
   "reportLoginHint": "Logging in attributes this report to your account",
+  "imageTooLarge": "Image size cannot exceed 5MB",
+  "invalidImageType": "Only JPG, PNG, and WebP image formats are supported",
   "nearbyHazards": "Nearby Hazard Reports",
   "confirmed": "Confirmed",
   "pending": "Pending",

--- a/src/i18n/locale/zh-TW/translation.json
+++ b/src/i18n/locale/zh-TW/translation.json
@@ -300,6 +300,8 @@
   "reportSuccess": "回報成功！感謝您的貢獻",
   "reportFailed": "回報失敗，請稍後再試",
   "reportLoginHint": "登入後回報會記在你的帳號下",
+  "imageTooLarge": "圖片大小不能超過 5MB",
+  "invalidImageType": "僅支援 JPG、PNG、WebP 等圖片格式",
   "nearbyHazards": "附近障礙物回報",
   "confirmed": "已確認",
   "pending": "待確認",

--- a/src/lib/api/__tests__/a11y.test.ts
+++ b/src/lib/api/__tests__/a11y.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHazardReport } from "@/lib/api/a11y";
+import { END_POINT } from "@/lib/config";
+import { ApiError } from "@/lib/fetch";
+import useAuthStore from "@/stores/useAuthStore";
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  statusText = "OK",
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function htmlResponse(
+  _html: string,
+  status = 502,
+  statusText = "Bad Gateway",
+): Response {
+  return {
+    ok: false,
+    status,
+    statusText,
+    json: async () => {
+      throw new SyntaxError("Unexpected token < in JSON at position 0");
+    },
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  useAuthStore.setState({ session: null, user: null });
+});
+
+describe("createHazardReport", () => {
+  it("resolves ok:true with hazard report data on 200/201 success", async () => {
+    let capturedUrl = "";
+    let capturedMethod = "";
+    let capturedBody: FormData | undefined;
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = String(url);
+        capturedMethod = init?.method ?? "GET";
+        capturedBody = init?.body as FormData;
+
+        return jsonResponse({
+          ok: true,
+          code: 201,
+          message: "Report created",
+          data: {
+            _id: "report-123",
+            hazardType: "obstacle",
+            latitude: 25.03396,
+            longitude: 121.56447,
+          },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formData = new FormData();
+    formData.append("hazardType", "obstacle");
+    formData.append("latitude", "25.03396");
+    formData.append("longitude", "121.56447");
+
+    const res = await createHazardReport(formData);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(capturedUrl).toBe(`${END_POINT}/api/v1/a11y/reports`);
+    expect(capturedMethod).toBe("POST");
+    expect(capturedBody).toBe(formData);
+    expect(res.ok).toBe(true);
+    expect(res.data?._id).toBe("report-123");
+  });
+
+  it("throws ApiError when backend returns a 400 JSON error envelope", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(
+        {
+          ok: false,
+          code: 400,
+          message: "Invalid hazard report payload",
+        },
+        400,
+        "Bad Request",
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formData = new FormData();
+    formData.append("hazardType", "invalid");
+
+    await expect(createHazardReport(formData)).rejects.toThrow(ApiError);
+    await expect(createHazardReport(formData)).rejects.toMatchObject({
+      code: 400,
+      message: "Invalid hazard report payload",
+    });
+  });
+
+  it("gracefully catches non-JSON error pages (502/504 HTML) and throws ApiError", async () => {
+    const fetchMock = vi.fn(async () =>
+      htmlResponse(
+        "<html><body>502 Bad Gateway</body></html>",
+        502,
+        "Bad Gateway",
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formData = new FormData();
+    formData.append("hazardType", "obstacle");
+
+    await expect(createHazardReport(formData)).rejects.toThrow(ApiError);
+    await expect(createHazardReport(formData)).rejects.toMatchObject({
+      code: 502,
+      message: "Bad Gateway",
+    });
+  });
+
+  it("attaches Authorization header when user is authenticated", async () => {
+    useAuthStore.setState({
+      session: {
+        accessToken: "test-jwt-token",
+      },
+    });
+
+    let capturedHeaders: Record<string, string> = {};
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+        return jsonResponse({
+          ok: true,
+          code: 200,
+          data: { _id: "report-123" },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const formData = new FormData();
+    await createHazardReport(formData);
+
+    expect(capturedHeaders.Authorization).toBe("Bearer test-jwt-token");
+  });
+});

--- a/src/lib/api/__tests__/placeSearch.test.ts
+++ b/src/lib/api/__tests__/placeSearch.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearReverseGeocodeCache,
+  getPlaceAutocomplete,
+  getPlaceDetails,
+  reverseGeocode,
+} from "@/lib/api/placeSearch";
+import { END_POINT } from "@/lib/config";
+import { ApiError } from "@/lib/fetch";
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  statusText = "OK",
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  clearReverseGeocodeCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("reverseGeocode", () => {
+  const mockNominatimData = {
+    place_id: 12345,
+    osm_id: 67890,
+    osm_type: "node",
+    lat: "25.03396",
+    lon: "121.56447",
+    display_name: "台北市信義區市府路1號",
+    name: "台北市政府",
+    address: {
+      city: "台北市",
+      city_district: "信義區",
+      road: "市府路",
+      house_number: "1號",
+      country: "臺灣",
+      country_code: "tw",
+    },
+  };
+
+  it("fetches reverse geocoding with object parameters and formats result", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Record<string, string> = {};
+
+    const fetchMock = vi.fn(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = String(url);
+        capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+        return jsonResponse(mockNominatimData);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await reverseGeocode({
+      lat: 25.03396,
+      lng: 121.56447,
+      lang: "zh-TW",
+      zoom: 18,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(capturedUrl).toContain(
+      "https://nominatim.openstreetmap.org/reverse",
+    );
+    expect(capturedUrl).toContain("lat=25.03396");
+    expect(capturedUrl).toContain("lon=121.56447");
+    expect(capturedUrl).toContain("accept-language=zh-TW");
+    expect(capturedUrl).toContain("zoom=18");
+    expect(capturedUrl).toContain("addressdetails=1");
+    expect(capturedHeaders["Accept-Language"]).toBe("zh-TW");
+
+    expect(result).not.toBeNull();
+    expect(result?.place_id).toBe(12345);
+    expect(result?.name).toBe("台北市政府");
+  });
+
+  it("supports positional parameters (lat, lng, lang, options)", async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toContain("zoom=16");
+      expect(String(url)).toContain("accept-language=en");
+      return jsonResponse(mockNominatimData);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await reverseGeocode(25.03396, 121.56447, "en", {
+      zoom: 16,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).not.toBeNull();
+  });
+
+  it("caches responses for repeated calls with same coordinates", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(mockNominatimData));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res1 = await reverseGeocode({
+      lat: 25.03396,
+      lng: 121.56447,
+      lang: "zh-TW",
+    });
+    const res2 = await reverseGeocode({
+      lat: 25.03396,
+      lng: 121.56447,
+      lang: "zh-TW",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res1).toEqual(res2);
+  });
+
+  it("clears cache via clearReverseGeocodeCache", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(mockNominatimData));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await reverseGeocode({ lat: 25.03396, lng: 121.56447, lang: "zh-TW" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    clearReverseGeocodeCache();
+
+    await reverseGeocode({ lat: 25.03396, lng: 121.56447, lang: "zh-TW" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null for non-finite coordinates", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await reverseGeocode({ lat: Number.NaN, lng: 121.56447 });
+    expect(res).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null when Nominatim returns an error payload", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ error: "Unable to geocode" }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await reverseGeocode({ lat: 0, lng: 0 });
+    expect(res).toBeNull();
+  });
+
+  it("throws ApiError when HTTP status is not ok (e.g. 500 / 429)", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({}, 500, "Internal Server Error"),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      reverseGeocode({ lat: 25.03396, lng: 121.56447 }),
+    ).rejects.toThrow(ApiError);
+  });
+
+  it("passes AbortSignal to fetch request", async () => {
+    const controller = new AbortController();
+    let passedSignal: AbortSignal | undefined;
+
+    const fetchMock = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        passedSignal = init?.signal as AbortSignal;
+        return jsonResponse(mockNominatimData);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await reverseGeocode({ lat: 25.03396, lng: 121.56447 }, controller.signal);
+
+    expect(passedSignal).toBe(controller.signal);
+  });
+});
+
+describe("getPlaceAutocomplete and getPlaceDetails", () => {
+  it("calls search autocomplete endpoint with query parameters", async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toContain(
+        `${END_POINT}/api/v1/a11y/search/autocomplete?q=taipei&lat=25.03&lng=121.56`,
+      );
+      return jsonResponse({
+        ok: true,
+        data: [{ id: "osm:node:123", title: "Taipei 101", address: "Xinyi" }],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await getPlaceAutocomplete({
+      q: "taipei",
+      lat: 25.03,
+      lng: 121.56,
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("calls search details endpoint with place ID", async () => {
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      expect(String(url)).toContain(
+        `${END_POINT}/api/v1/a11y/search/details/osm%3Anode%3A123`,
+      );
+      return jsonResponse({
+        ok: true,
+        data: { id: "osm:node:123", name: "Taipei 101" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await getPlaceDetails("osm:node:123", {});
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/lib/api/a11y.ts
+++ b/src/lib/api/a11y.ts
@@ -1,5 +1,6 @@
 ﻿import { END_POINT } from "@/lib/config";
 import {
+  ApiError,
   authenticatedRequest,
   fetchRequest,
   getAccessToken,
@@ -86,7 +87,38 @@ export async function createHazardReport(formData: FormData) {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     body: formData,
   });
-  return response.json() as Promise<ApiResponse<HazardReport>>;
+
+  const hasBody = response.status !== 204 && response.status !== 205;
+  let data: ApiResponse<HazardReport>;
+  if (hasBody) {
+    try {
+      data = (await response.json()) as ApiResponse<HazardReport>;
+    } catch {
+      throw new ApiError(
+        response.statusText || "Failed to submit hazard report",
+        response.status,
+      );
+    }
+  } else {
+    data = {
+      ok: response.ok,
+      status: response.ok ? "success" : "error",
+      code: response.status,
+      message: response.statusText,
+    } as ApiResponse<HazardReport>;
+  }
+
+  const isSuccess = data.ok === true || data.success === true;
+  if (!isSuccess) {
+    throw new ApiError(
+      data.message || "Failed to submit hazard report",
+      data.code || response.status,
+      (data.data as { reason?: string } | undefined)?.reason,
+      data.data,
+    );
+  }
+
+  return data;
 }
 
 export async function getNearbyHazardReports(

--- a/src/lib/api/placeSearch.ts
+++ b/src/lib/api/placeSearch.ts
@@ -1,9 +1,157 @@
 import { END_POINT } from "@/lib/config";
-import { fetchRequest } from "@/lib/fetch";
+import { ApiError, fetchRequest } from "@/lib/fetch";
+import { formatNominatimPlace } from "@/lib/utils";
+import type { NominatimPlace } from "@/types";
 import type { AutocompleteItem, PlaceResult } from "@/types/place";
 import type { ApiResponse } from "@/types/response";
 
 const BASE = `${END_POINT}/api/v1/a11y/search`;
+
+export interface ReverseGeocodeParams {
+  lat: number;
+  lng: number;
+  lang?: string;
+  zoom?: number;
+  addressdetails?: number;
+}
+
+export interface ReverseGeocodeOptions {
+  zoom?: number;
+  addressdetails?: number;
+  signal?: AbortSignal;
+}
+
+interface ReverseCacheEntry {
+  place: NominatimPlace;
+  timestamp: number;
+}
+
+const REVERSE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const REVERSE_CACHE_MAX_ENTRIES = 200;
+const reverseGeocodeCache = new Map<string, ReverseCacheEntry>();
+
+export function clearReverseGeocodeCache() {
+  reverseGeocodeCache.clear();
+}
+
+/**
+ * Reverse geocode latitude/longitude coordinates to OSM Nominatim place details.
+ * Encapsulates in-memory caching, custom headers, structured error handling,
+ * and OSM format normalization via formatNominatimPlace.
+ */
+export async function reverseGeocode(
+  latOrParams: number | ReverseGeocodeParams,
+  lngOrSignal?: number | AbortSignal | ReverseGeocodeOptions,
+  langParam?: string,
+  optionsParam?: ReverseGeocodeOptions,
+): Promise<NominatimPlace | null> {
+  let lat: number;
+  let lng: number;
+  let lang = "zh-TW";
+  let zoom = 18;
+  let addressdetails = 1;
+  let signal: AbortSignal | undefined;
+
+  if (typeof latOrParams === "object" && latOrParams !== null) {
+    lat = latOrParams.lat;
+    lng = latOrParams.lng;
+    if (latOrParams.lang) lang = latOrParams.lang;
+    if (latOrParams.zoom !== undefined) zoom = latOrParams.zoom;
+    if (latOrParams.addressdetails !== undefined)
+      addressdetails = latOrParams.addressdetails;
+
+    if (lngOrSignal instanceof AbortSignal) {
+      signal = lngOrSignal;
+    } else if (typeof lngOrSignal === "object" && lngOrSignal !== null) {
+      const opts = lngOrSignal as ReverseGeocodeOptions;
+      signal = opts.signal;
+      if (opts.zoom !== undefined) {
+        zoom = opts.zoom;
+      }
+      if (opts.addressdetails !== undefined) {
+        addressdetails = opts.addressdetails;
+      }
+    }
+  } else {
+    lat = latOrParams;
+    lng = lngOrSignal as number;
+    if (langParam) lang = langParam;
+    if (optionsParam?.zoom !== undefined) zoom = optionsParam.zoom;
+    if (optionsParam?.addressdetails !== undefined)
+      addressdetails = optionsParam.addressdetails;
+    signal = optionsParam?.signal;
+  }
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return null;
+  }
+
+  const cacheKey = `${lat.toFixed(5)},${lng.toFixed(5)},${lang},${zoom},${addressdetails}`;
+  const now = Date.now();
+  const cached = reverseGeocodeCache.get(cacheKey);
+  if (cached && now - cached.timestamp < REVERSE_CACHE_TTL_MS) {
+    return structuredClone(cached.place);
+  }
+
+  const query = new URLSearchParams({
+    format: "json",
+    lat: String(lat),
+    lon: String(lng),
+    "accept-language": lang,
+    zoom: String(zoom),
+    addressdetails: String(addressdetails),
+  });
+
+  const url = `https://nominatim.openstreetmap.org/reverse?${query.toString()}`;
+
+  const headers: Record<string, string> = {
+    "Accept-Language": lang,
+  };
+
+  try {
+    headers["User-Agent"] =
+      "TaipeiAccessibleMap/1.0 (https://taipei-accessible-map.org)";
+  } catch {
+    // Ignore restricted header errors if any
+  }
+
+  const res = await fetch(url, {
+    method: "GET",
+    headers,
+    signal,
+  });
+
+  if (!res.ok) {
+    throw new ApiError(
+      `Reverse geocoding failed with status ${res.status}`,
+      res.status,
+    );
+  }
+
+  const data = (await res.json()) as
+    | (NominatimPlace & { error?: string })
+    | null;
+  if (!data || data.error) {
+    return null;
+  }
+
+  const formatted = formatNominatimPlace(data, lang);
+  if (!formatted) {
+    return null;
+  }
+
+  if (reverseGeocodeCache.size >= REVERSE_CACHE_MAX_ENTRIES) {
+    const oldestKey = reverseGeocodeCache.keys().next().value;
+    if (oldestKey) reverseGeocodeCache.delete(oldestKey);
+  }
+
+  reverseGeocodeCache.set(cacheKey, {
+    place: structuredClone(formatted),
+    timestamp: now,
+  });
+
+  return formatted;
+}
 
 export async function getPlaceAutocomplete(
   params: {

--- a/src/lib/map/__tests__/gpsErrorHandler.test.ts
+++ b/src/lib/map/__tests__/gpsErrorHandler.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGpsErrorTracker,
+  createGpsPositionHandlers,
+} from "../gpsErrorHandler";
+
+describe("createGpsErrorTracker", () => {
+  it("initializes with hasError = false", () => {
+    const tracker = createGpsErrorTracker();
+    expect(tracker.hasError()).toBe(false);
+  });
+
+  it("triggers notify and returns true on the first error transition", () => {
+    const tracker = createGpsErrorTracker();
+    const notify = vi.fn();
+
+    const result = tracker.recordError(notify);
+
+    expect(result).toBe(true);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(tracker.hasError()).toBe(true);
+  });
+
+  it("suppresses notifications on subsequent consecutive errors", () => {
+    const tracker = createGpsErrorTracker();
+    const notify = vi.fn();
+
+    // First error: transitions to error state
+    expect(tracker.recordError(notify)).toBe(true);
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // Repeated consecutive errors (e.g. watchPosition firing every 1s without signal)
+    for (let i = 0; i < 10; i++) {
+      expect(tracker.recordError(notify)).toBe(false);
+    }
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(tracker.hasError()).toBe(true);
+  });
+
+  it("resets error state on recordSuccess and allows notification on subsequent error", () => {
+    const tracker = createGpsErrorTracker();
+    const notify = vi.fn();
+
+    // 1. Initial error occurs
+    tracker.recordError(notify);
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(tracker.hasError()).toBe(true);
+
+    // 2. GPS fix acquired (recovery)
+    tracker.recordSuccess();
+    expect(tracker.hasError()).toBe(false);
+
+    // 3. New error occurs (e.g. user enters basement again)
+    const result = tracker.recordError(notify);
+    expect(result).toBe(true);
+    expect(notify).toHaveBeenCalledTimes(2);
+    expect(tracker.hasError()).toBe(true);
+  });
+
+  it("resets error state via reset()", () => {
+    const tracker = createGpsErrorTracker();
+    tracker.recordError();
+    expect(tracker.hasError()).toBe(true);
+
+    tracker.reset();
+    expect(tracker.hasError()).toBe(false);
+  });
+});
+
+describe("createGpsPositionHandlers", () => {
+  let mockStorage: Record<string, string>;
+  let storage: {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+  };
+
+  beforeEach(() => {
+    mockStorage = {};
+    storage = {
+      getItem: (key: string) => mockStorage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mockStorage[key] = value;
+      },
+    };
+  });
+
+  const createMockPosition = (
+    lat: number,
+    lng: number,
+    heading: number | null = null,
+  ): GeolocationPosition =>
+    ({
+      coords: {
+        latitude: lat,
+        longitude: lng,
+        accuracy: 10,
+        altitude: null,
+        altitudeAccuracy: null,
+        heading,
+        speed: null,
+        toJSON: () => ({}),
+      },
+      timestamp: Date.now(),
+      toJSON: () => ({}),
+    }) as unknown as GeolocationPosition;
+
+  it("handles valid position updates and writes to storage", () => {
+    const onLocationUpdate = vi.fn();
+    const onHeadingUpdate = vi.fn();
+
+    const { handlePosition } = createGpsPositionHandlers({
+      onLocationUpdate,
+      onHeadingUpdate,
+      storage,
+    });
+
+    const pos = createMockPosition(25.033, 121.565, 180);
+    handlePosition(pos);
+
+    expect(onLocationUpdate).toHaveBeenCalledWith({
+      lat: 25.033,
+      lng: 121.565,
+    });
+    expect(onHeadingUpdate).toHaveBeenCalledWith(180);
+    expect(mockStorage.lastUserLocation).toBe(
+      JSON.stringify({ lat: 25.033, lng: 121.565 }),
+    );
+  });
+
+  it("handles heading with null or NaN correctly", () => {
+    const onLocationUpdate = vi.fn();
+    const onHeadingUpdate = vi.fn();
+
+    const { handlePosition } = createGpsPositionHandlers({
+      onLocationUpdate,
+      onHeadingUpdate,
+      storage,
+    });
+
+    handlePosition(createMockPosition(25.033, 121.565, Number.NaN));
+    expect(onHeadingUpdate).toHaveBeenLastCalledWith(null);
+
+    handlePosition(createMockPosition(25.033, 121.565, null));
+    expect(onHeadingUpdate).toHaveBeenLastCalledWith(null);
+  });
+
+  it("handles storage write failures gracefully without throwing", () => {
+    const onLocationUpdate = vi.fn();
+    const failingStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("QuotaExceededError");
+      },
+    };
+
+    const { handlePosition } = createGpsPositionHandlers({
+      onLocationUpdate,
+      storage: failingStorage,
+    });
+
+    expect(() => {
+      handlePosition(createMockPosition(25.033, 121.565));
+    }).not.toThrow();
+    expect(onLocationUpdate).toHaveBeenCalledWith({
+      lat: 25.033,
+      lng: 121.565,
+    });
+  });
+
+  it("notifies error on first failure and suppresses consecutive errors", () => {
+    const onLocationUpdate = vi.fn();
+    const onErrorNotification = vi.fn();
+
+    const { handlePosition, handleError, tracker } = createGpsPositionHandlers({
+      onLocationUpdate,
+      onErrorNotification,
+      storage,
+    });
+
+    const mockError = {
+      code: 1, // PERMISSION_DENIED
+      message: "User denied Geolocation",
+      PERMISSION_DENIED: 1,
+      POSITION_UNAVAILABLE: 2,
+      TIMEOUT: 3,
+    } as GeolocationPositionError;
+
+    // First error: notification fired
+    handleError(mockError);
+    expect(onErrorNotification).toHaveBeenCalledTimes(1);
+    expect(onErrorNotification).toHaveBeenCalledWith(mockError);
+    expect(tracker.hasError()).toBe(true);
+
+    // Repeated consecutive errors: notification suppressed
+    handleError(mockError);
+    handleError(mockError);
+    handleError(mockError);
+    expect(onErrorNotification).toHaveBeenCalledTimes(1);
+
+    // Position recovery: resets error state
+    handlePosition(createMockPosition(25.033, 121.565));
+    expect(tracker.hasError()).toBe(false);
+
+    // Subsequent error: notification fired again
+    handleError(mockError);
+    expect(onErrorNotification).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/map/gpsErrorHandler.ts
+++ b/src/lib/map/gpsErrorHandler.ts
@@ -1,0 +1,110 @@
+/**
+ * State-transition GPS error tracker and position handlers.
+ *
+ * Prevents toast notification spam when `navigator.geolocation.watchPosition`
+ * continuously fires error callbacks (e.g. in tunnels, basements, or when
+ * location permission is denied).
+ *
+ * Notifications are only dispatched on the transition from a healthy/initial
+ * state to an error state. Once a valid GPS fix is received, the error state
+ * is reset so future signal losses will trigger a single notification again.
+ */
+
+import type { LatLng } from "@/types";
+
+export interface GpsErrorTracker {
+  /** Record a successful GPS position fix; resets the error state. */
+  recordSuccess: () => void;
+  /**
+   * Record a GPS error. Calls `notify` ONLY if transitioning into the error state.
+   * Returns `true` if this was a new error transition, `false` if suppressed.
+   */
+  recordError: (notify?: () => void) => boolean;
+  /** Check whether the tracker is currently in an error state. */
+  hasError: () => boolean;
+  /** Explicitly reset the error state. */
+  reset: () => void;
+}
+
+/**
+ * Creates a state-transition GPS error tracker instance.
+ */
+export function createGpsErrorTracker(): GpsErrorTracker {
+  let isErrorActive = false;
+
+  return {
+    recordSuccess: () => {
+      isErrorActive = false;
+    },
+    recordError: (notify?: () => void) => {
+      if (!isErrorActive) {
+        isErrorActive = true;
+        notify?.();
+        return true;
+      }
+      return false;
+    },
+    hasError: () => isErrorActive,
+    reset: () => {
+      isErrorActive = false;
+    },
+  };
+}
+
+export interface GpsPositionHandlersOptions {
+  onLocationUpdate: (loc: LatLng) => void;
+  onHeadingUpdate?: (heading: number | null) => void;
+  onErrorNotification?: (error?: GeolocationPositionError) => void;
+  storageKey?: string;
+  storage?: Pick<Storage, "getItem" | "setItem"> | null;
+  tracker?: GpsErrorTracker;
+}
+
+/**
+ * Creates coordinated position and error handlers for navigator.geolocation.
+ */
+export function createGpsPositionHandlers(options: GpsPositionHandlersOptions) {
+  const {
+    onLocationUpdate,
+    onHeadingUpdate,
+    onErrorNotification,
+    storageKey = "lastUserLocation",
+    storage = typeof window !== "undefined" ? window.localStorage : null,
+    tracker = createGpsErrorTracker(),
+  } = options;
+
+  const handlePosition = (pos: GeolocationPosition) => {
+    tracker.recordSuccess();
+
+    const loc: LatLng = {
+      lat: pos.coords.latitude,
+      lng: pos.coords.longitude,
+    };
+    onLocationUpdate(loc);
+
+    if (storage) {
+      try {
+        storage.setItem(storageKey, JSON.stringify(loc));
+      } catch (_err) {
+        // localStorage write failure (e.g. private browsing or quota exceeded) is non-fatal.
+      }
+    }
+
+    if (onHeadingUpdate) {
+      const h = pos.coords.heading;
+      onHeadingUpdate(typeof h === "number" && !Number.isNaN(h) ? h : null);
+    }
+  };
+
+  const handleError = (error?: GeolocationPositionError) => {
+    tracker.recordError(() => {
+      onErrorNotification?.(error);
+    });
+  };
+
+  return {
+    handlePosition,
+    handleError,
+    tracker,
+  };
+}


### PR DESCRIPTION
## 概要

本 PR 接續已合併之 Phase 1-3，依據產品級工程稽核報告完成 Phase 4, 5, 6 關鍵修復與工程優化：

---

### 1. Phase 4：優化 GPS 錯誤處理防 Toast 轟炸 (P1-4)
- **建立狀態轉移型定位錯誤處理器 (`src/lib/map/gpsErrorHandler.ts`)**：
  - 在 `ClientMap.tsx` 的 `watchPosition` 錯誤回呼中加入狀態追蹤，僅在**定位狀態首次進入錯誤狀態時提示一次**，徹底解決無訊號/地下道時每秒狂發 Toast 覆蓋畫面的問題。
  - 當定位恢復正常時自動重置錯誤狀態，支援自動恢復。
- **單元測試**：新增 `src/lib/map/__tests__/gpsErrorHandler.test.ts` 驗證狀態防抖與單次提示邏輯。

---

### 2. Phase 5：收斂 Nominatim 呼叫與修正 API 錯誤防護 (P2-1, P2-4, P2-5)
- **收斂 Nominatim 反向地理編碼 API (P2-1)**：
  - 在 `src/lib/api/placeSearch.ts` 建立集中式 `reverseGeocode()`，內建自訂 User-Agent、記憶體快取與統一錯誤解析。
  - 將 `ClientMap.tsx`、`SosDialog.tsx`、`HazardReportPanel.tsx`、`MapControlsWrapper.tsx` 共 5 處寫死之 URL 呼叫全數收斂。
- **修復 `createHazardReport` 錯誤防護 (P2-4)**：
  - `src/lib/api/a11y.ts` 封裝健全的 HTTP 狀態碼與 `ApiError` 處理，防止 502/504 導致未捕獲的 SyntaxError。
- **補齊圖片上傳客戶端檢查 (P2-5)**：
  - `HazardReportPanel.tsx` 加上 5MB 檔案大小上限與 MIME 類型檢查，防止超大圖檔造成行動端記憶體崩潰。
- **單元測試**：新增 `placeSearch.test.ts`、`a11y.test.ts` 與 `HazardReportPanel.test.ts`。

---

### 3. Phase 6：實施 Code Splitting 降低首頁體積 (P2-3)
- **動態按需載入（`next/dynamic`）**：
  - 將 `BottomSheet` 次級面板（`EnvironmentPanel`, `WelfarePanel`, `HazardReportPanel`, `ParkingPanel`, `StationDetailContent`, `BusPanel`, `RouteExplanationPanel`, `SavedPlacesPanel`）與重型元件（`AIChatBot`, `VoiceSessionHost`, `SosDialog`, `OnboardingFlow`）改為動態載入。
  - 依據 `ui-ux-pro-max` 規範打造無障礙骨架屏 (`PanelSkeletons.tsx`)，確保載入過程無版面跳動 (Zero CLS)。
- **體積優化結果**：首頁 `/[lng]` First Load JS 由 **815 kB 顯著降至 698 kB**。

---

### 驗證結果
- [x] `npm run lint` ➜ 0 errors, 0 warnings across 230 files
- [x] `npx tsc --noEmit` ➜ 0 errors
- [x] `npm test` ➜ 29 test suites passed, 257 tests passed
- [x] `npm run check:cycles` ➜ 0 circular dependencies
- [x] `npm run build` ➜ Next.js 15 Turbopack production build succeeded (698 kB First Load JS)